### PR TITLE
Update Collection-of-Custom-Formats-for-RadarrV3.md

### DIFF
--- a/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -233,7 +233,7 @@ Custom format for several Special Editions
     ```json
     {
         "name": "HDR",
-        "includeCustomFormatWhenRenaming": true,
+        "includeCustomFormatWhenRenaming": false,
         "specifications": [{
             "name": "HDR",
             "implementation": "ReleaseTitleSpecification",


### PR DESCRIPTION
Fixed the double HDR showing in the naming scheme if `{[Custom Formats]}` is been used