### PR TITLE
Update Sonarr-Release-Profile-RegEx.md

### DIFF
--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
@@ -79,7 +79,7 @@ The Number between the **[**brackets**]** are the scores the release name will g
 [100]   /(atvp).?web.?(dl|rip)/i
 [100]   /(hmax).?web.?(dl|rip)/i
 [90]   /(dsnp|dsny|disney).?web.?(dl|rip)/i
-[90]   /(nf|netflix).?(dl|rip)/i
+[90]   /(nf|netflix).?web.?(dl|rip)/i
 [90]   /(qibi).?web.?(dl|rip)/i
 [85]   /(hulu).?web.?(dl|rip)/i
 [75]   /(dcu).?web.?(dl|rip)/i


### PR DESCRIPTION
Updated: Sonarr Release Profile RegEx (WEB-DL)
- Fixed: /(nf|netflix).?(dl|rip)/i to /(nf|netflix).?web.?(dl|rip)/i for adding the preferred words into the file name

Co-Authored-By: g4m3r7ag <46694420+g4m3r7ag@users.noreply.github.com>