### PR TITLE
Add non-capturing groups to Sonarr Release Source regex

### DIFF
--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
@@ -79,17 +79,17 @@ It's recommended to add the Release Sources separate from the other release prof
 
 ```bash
 # Preferred (3)
-[100]   /(amzn|amazon).?web.?(dl|rip)/i
-[100]   /(atvp).?web.?(dl|rip)/i
-[100]   /(hmax).?web.?(dl|rip)/i
-[90]   /(dsnp|dsny|disney).?web.?(dl|rip)/i
-[90]   /(nf|netflix).?web.?(dl|rip)/i
-[90]   /(qibi).?web.?(dl|rip)/i
-[85]   /(hulu).?web.?(dl|rip)/i
-[75]   /(dcu).?web.?(dl|rip)/i
-[75]   /(hbo).?web.?(dl|rip)/i
-[75]   /(red).?web.?(dl|rip)/i
-[75]   /(it).?web.?(dl|rip)/i
+[100]   /(amzn|amazon)(?=.?web.?(dl|rip))/i
+[100]   /(atvp)(?=.?web.?(dl|rip))/i
+[100]   /(hmax)(?=.?web.?(dl|rip))/i
+[90]   /(dsnp|dsny|disney)(?=.?web.?(dl|rip))i
+[90]   /(nf|netflix)(?=.?web.?(dl|rip))/i
+[90]   /(qibi)(?=.?web.?(dl|rip))/i
+[85]   /(hulu)(?=.?web.?(dl|rip))/i
+[75]   /(dcu)(?=.?web.?(dl|rip))/i
+[75]   /(hbo)(?=.?web.?(dl|rip))/i
+[75]   /(red)(?=.?web.?(dl|rip))/i
+[75]   /(it)(?=.?web.?(dl|rip))/i
 ```
 
 !!! note

--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
@@ -82,7 +82,7 @@ It's recommended to add the Release Sources separate from the other release prof
 [100]   /(amzn|amazon)(?=.?web.?(dl|rip))/i
 [100]   /(atvp)(?=.?web.?(dl|rip))/i
 [100]   /(hmax)(?=.?web.?(dl|rip))/i
-[90]   /(dsnp|dsny|disney)(?=.?web.?(dl|rip))i
+[90]   /(dsnp|dsny|disney)(?=.?web.?(dl|rip))/i
 [90]   /(nf|netflix)(?=.?web.?(dl|rip))/i
 [90]   /(qibi)(?=.?web.?(dl|rip))/i
 [85]   /(hulu)(?=.?web.?(dl|rip))/i


### PR DESCRIPTION
By making the release quality type (i.e.: webdl/rip) part of a non-capturing group, renames with {Preferred Words} won't overlap with {Quality Title} (e.g.: WEB-DL won't occur twice).