### PR TITLE
Update Sonarr-Release-Profile-RegEx.md

### DIFF
--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
@@ -75,13 +75,16 @@ The Number between the **[**brackets**]** are the scores the release name will g
 
 ### Release Source (Streaming Service)
 
-It's recommended to add the Release Sources separate from the other release profiles.
+!!! tip
+
+    It's recommended to add the Release Sources separate from the other release profiles.
 
 ```bash
 # Preferred (3)
 [100]   /(amzn|amazon)(?=.?web.?(dl|rip))/i
 [100]   /(atvp)(?=.?web.?(dl|rip))/i
 [100]   /(hmax)(?=.?web.?(dl|rip))/i
+[95]   /(sho)(?=.?web.?(dl|rip))/i
 [90]   /(dsnp|dsny|disney)(?=.?web.?(dl|rip))/i
 [90]   /(nf|netflix)(?=.?web.?(dl|rip))/i
 [90]   /(qibi)(?=.?web.?(dl|rip))/i


### PR DESCRIPTION
Updated: Sonarr Release Profile RegEx (WEB-DL)
- Added: Showtime (Quality wise Showtime is excelent but audio from showtime is only 384kbs DD 5.1 but the rippers/encoders are adding the Amazon is 640kbp DD+ 5.1 to it