### PR TITLE
Update Sonarr-recommended-naming-scheme.md

### DIFF
--- a/docs/Sonarr/V3/Sonarr-recommended-naming-scheme.md
+++ b/docs/Sonarr/V3/Sonarr-recommended-naming-scheme.md
@@ -16,7 +16,7 @@ The Tokens not available in the release won't be used/shown.
 > **All the details**
 
 ```bash
-{Series TitleYear} - S{season:00}E{episode:00} - {Episode CleanTitle} [{Preferred Words }{Quality Full}]{[MediaInfo VideoDynamicRange]}[{MediaInfo VideoBitDepth}bit]{[MediaInfo VideoCodec]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo AudioLanguages]}{-Release Group}
+{Series TitleYear} - S{season:00}E{episode:00} - {Episode CleanTitle} [{Preferred Words }{Quality Full}]{[MediaInfo VideoDynamicRange]}[{MediaInfo VideoBitDepth}bit]{[MediaInfo VideoCodec]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{-Release Group}
 ```
 
 ??? summary "RESULTS:"
@@ -52,7 +52,7 @@ The Tokens not available in the release won't be used/shown.
 > **All the details**
 
 ```bash
-{Series TitleYear} - {Air-Date} - {Episode CleanTitle} [{Preferred Words }{Quality Full}]{[MediaInfo VideoDynamicRange]}[{MediaInfo VideoBitDepth}bit]{[MediaInfo VideoCodec]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{[MediaInfo AudioLanguages]}{-Release Group}
+{Series TitleYear} - {Air-Date} - {Episode CleanTitle} [{Preferred Words }{Quality Full}]{[MediaInfo VideoDynamicRange]}[{MediaInfo VideoBitDepth}bit]{[MediaInfo VideoCodec]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels]}{MediaInfo AudioLanguages}{-Release Group}
 ```
 
 ??? summary "RESULTS:"


### PR DESCRIPTION
- Removed: Brackets for {[MediaInfo AudioLanguages]} to {MediaInfo AudioLanguages} forgot it for Standard Episode/Daily Episode Format