### PR TITLE
Maintanance release 20210110

### DIFF
--- a/docs/Misc/how-to-set-up-hardlinks-and-atomic-moves.md
+++ b/docs/Misc/how-to-set-up-hardlinks-and-atomic-moves.md
@@ -526,10 +526,10 @@ Then keep reading.
     sudo chmod -R a=,a+rX,u+w,g+w /volume1/data /volume1/docker
     ```
 
+    ##### Run the Docker Compose
+
     !!! important
         make sure you deleted/removed all your existing dockers from the GUI and also remove your native installs of these applications !!!
-
-    ##### Run the Docker Compose
 
     When you did all the above steps you only need to type the following in your `/volume1/docker/appdata`
 

--- a/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -3015,7 +3015,7 @@ If you prefer movies with also a Dutch audio track.
                 "negate": false,
                 "required": false,
                 "fields": {
-                    "value": "dual\\.audio"
+                    "value": "dual.?audio"
                 }
             },
             {

--- a/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -50,7 +50,7 @@ I also made a [Guide](How-to-importexport-Custom-Formats-and-truly-make-use-of-i
 | [Dolby Vision](#dolby-vision)                             | [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                           | [Repack/Proper](#repack-proper)           |
 | [Dolby Vision (Single Layer)](#dolby-vision-single-layer) | [Remaster](#remaster)                         | [EVO except WEB-DL](#evo-except-web-dl)       | [Streaming Services](#streaming-services) |
 | [HDR](#hdr)                                               | [4K Remaster](#4k-remaster)                   | [Low Quality Releases](#low-quality-releases) | [HQ-P2P](#hq-p2p)                         |
-| [HDR (FraMeSToR)](#hdr-framestor)                         | [Special Editions](#special-edition)          | [720/1080p no x265](#7201080p-no-x265)        | [x264](#x264)                             |
+| [HDR (indeterminate)](#hdr-indeterminate)                         | [Special Editions](#special-edition)          | [720/1080p no x265](#7201080p-no-x265)        | [x264](#x264)                             |
 | [10 Bit](#10-bit)                                         | [Criterion Collection](#criterion-collection) | [3D](#3d)                                     | [x265](#x265)                             |
 |                                                           | [Theatrical Cut](#theatrical-cut)             |                                               | [MPEG2](#mpeg2)                           |
 |                                                           | [IMAX](#imax)                                 |                                               | [FreeLeech](#freeleech)                   |
@@ -2002,15 +2002,17 @@ High-dynamic-range video (HDR video) is video having a dynamic range greater tha
 
 ------
 
-### HDR-FraMeSToR
+### HDR (indeterminate)
 
-FraMeSToR doesn't add HDR to their 4K release name so I suggest to add this Custom Format at the same score as you add one of your HDR Custom Formats.
+Some groups don't add HDR to their 4K release name so I suggest to add this Custom Format at the same score as you add one of your HDR Custom Formats.
+
+For now it's only FraMeSToR that doesn't add HDR to their release name but in the feature we can add more to it if needed.
 
 ??? example "json"
 
     ```json
     {
-      "name": "HDR (FraMeSToR)",
+      "name": "HDR (indeterminate)",
       "includeCustomFormatWhenRenaming": false,
       "specifications": [
         {

--- a/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -50,14 +50,14 @@ I also made a [Guide](How-to-importexport-Custom-Formats-and-truly-make-use-of-i
 | [Dolby Vision](#dolby-vision)                             | [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                           | [Repack/Proper](#repack-proper)           |
 | [Dolby Vision (Single Layer)](#dolby-vision-single-layer) | [Remaster](#remaster)                         | [EVO except WEB-DL](#evo-except-web-dl)       | [Streaming Services](#streaming-services) |
 | [HDR](#hdr)                                               | [4K Remaster](#4k-remaster)                   | [Low Quality Releases](#low-quality-releases) | [HQ-P2P](#hq-p2p)                         |
-| [10 Bit](#10-bit)                                         | [Special Editions](#special-edition)          | [720/1080p no x265](#7201080p-no-x265)        | [x264](#x264)                             |
-|                                                           | [Criterion Collection](#criterion-collection) | [3D](#3d)                                     | [x265](#x265)                             |
+| [HDR (FraMeSToR)](#hdr-framestor)                         | [Special Editions](#special-edition)          | [720/1080p no x265](#7201080p-no-x265)        | [x264](#x264)                             |
+| [10 Bit](#10-bit)                                         | [Criterion Collection](#criterion-collection) | [3D](#3d)                                     | [x265](#x265)                             |
 |                                                           | [Theatrical Cut](#theatrical-cut)             |                                               | [MPEG2](#mpeg2)                           |
 |                                                           | [IMAX](#imax)                                 |                                               | [FreeLeech](#freeleech)                   |
 |                                                           |                                               |                                               | [Dutch Groups](#dutch-groups)             |
 |                                                           |                                               |                                               | [Anime Dual Audio](#anime-dual-audio)     |
 |                                                           |                                               |                                               | [Multi](#multi)                           |
-|                                                           |                                               |                                               | [FraMeSToR](#framestor)                   |
+|                                                           |                                               |                                               |                                           |
 
 ## Audio
 
@@ -2002,6 +2002,70 @@ High-dynamic-range video (HDR video) is video having a dynamic range greater tha
 
 ------
 
+### HDR-FraMeSToR
+
+FraMeSToR doesn't add HDR to their 4K release name so I suggest to add this Custom Format at the same score as you add one of your HDR Custom Formats.
+
+??? example "json"
+
+    ```json
+    {
+      "name": "HDR (FraMeSToR)",
+      "includeCustomFormatWhenRenaming": false,
+      "specifications": [
+        {
+          "name": "FraMeSToR",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": true,
+          "fields": {
+            "value": "\\bFraMeSToR\\b"
+          }
+        },
+        {
+          "name": "2160p",
+          "implementation": "ResolutionSpecification",
+          "negate": false,
+          "required": true,
+          "fields": {
+            "value": 2160
+          }
+        },
+        {
+          "name": "HDR: HDR",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": true,
+          "required": true,
+          "fields": {
+            "value": "\\bHDR(\\b|\\d)"
+          }
+        },
+        {
+          "name": "DoVi: Dolby Vision",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": true,
+          "required": true,
+          "fields": {
+            "value": "\\b(DV|dovi)\\b|dolby.?vision"
+          }
+        },
+        {
+          "name": "SDR: SDR",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": true,
+          "required": true,
+          "fields": {
+            "value": "\\bSDR(\\b|\\d)"
+          }
+        }
+      ]
+    }
+    ```
+
+<sub><sup>[TOP](#index)</sup></sub>
+
+------
+
 ### 10 Bit
 
 ??? example "json"
@@ -3037,34 +3101,6 @@ If you prefer movies with also a Dutch audio track.
                 "value": "\\bMulti(\\b|\\d)"
             }
         }]
-    }
-    ```
-
-<sub><sup>[TOP](#index)</sup></sub>
-
-------
-
-### FraMeSToR
-
-If you prefer FraMeSToR releases.
-
-Also FraMeSToR doesn't add HDR to their release name so I suggest to add them at the same score as you add one of your HDR Custom Formats.
-
-??? example "json"
-
-    ```json
-    {
-        "name": "FraMeSToR",
-        "includeCustomFormatWhenRenaming": false,
-        "specifications": [{
-            "name": "FraMeSToR",
-            "implementation": "ReleaseTitleSpecification",
-            "negate": false,
-            "required": true,
-            "fields": {
-              "value": "\\bFraMeSToR\\b"
-         }
-       }]
     }
     ```
 

--- a/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
+++ b/docs/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3.md
@@ -3007,54 +3007,55 @@ If you prefer movies with also a Dutch audio track.
 
     ```json
     {
-        "name": "Anime Dual Audio",
-        "includeCustomFormatWhenRenaming": false,
-        "specifications": [{
-                "name": "Dual Audio",
-                "implementation": "ReleaseTitleSpecification",
-                "negate": false,
-                "required": false,
-                "fields": {
-                    "value": "dual.?audio"
-                }
-            },
-            {
-                "name": "BluDragon",
-                "implementation": "ReleaseTitleSpecification",
-                "negate": false,
-                "required": false,
-                "fields": {
-                    "value": "bludragon"
-                }
-            },
-            {
-                "name": "EN+JA",
-                "implementation": "ReleaseTitleSpecification",
-                "negate": false,
-                "required": false,
-                "fields": {
-                    "value": "EN\\+JA|JA\\+EN"
-                }
-            },
-            {
-                "name": "ZR",
-                "implementation": "ReleaseTitleSpecification",
-                "negate": false,
-                "required": false,
-                "fields": {
-                    "value": "\\bZR\\b"
-                }
-            },
-            {
-                "name": "Japanese Language",
-                "implementation": "LanguageSpecification",
-                "negate": false,
-                "required": true,
-                "fields": {
-                    "value": 8
-                }
-            }
-        ]
+      "name": "Anime Dual Audio",
+      "includeCustomFormatWhenRenaming": false,
+      "specifications": [
+        {
+          "name": "Dual Audio",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+            "value": "dual.?audio"
+          }
+        },
+        {
+          "name": "BluDragon",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+            "value": "bludragon"
+          }
+        },
+        {
+          "name": "EN+JA",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+            "value": "EN\\+JA|JA\\+EN"
+          }
+        },
+        {
+          "name": "ZR",
+          "implementation": "ReleaseTitleSpecification",
+          "negate": false,
+          "required": false,
+          "fields": {
+            "value": "\\bZR\\b"
+          }
+        },
+        {
+          "name": "Japanese Language",
+          "implementation": "LanguageSpecification",
+          "negate": false,
+          "required": true,
+          "fields": {
+            "value": 8
+          }
+        }
+      ]
     }
     ```
 

--- a/docs/Radarr/V3/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/V3/Radarr-recommended-naming-scheme.md
@@ -78,6 +78,14 @@ RESULT:
 !!! note
     Keep in mind adding anything more after the release year could give issues during a fresh import in to Radarr, but in this examples it helps for movies that have the same release name and year.
 
+!!! hint
+
+    Radarr now supports iMDb ID and TMDb ID in the folder name.
+
+    !!! quote "Quote From the a developer"
+
+        TMDb is usually better as it guarantees a match, imdb only gets matched if the TMDb entry has the correct imdb Id association. We don't actually talk to imdb
+
 !!! warning
     Please note that this pins the IMDb ID whenever the movie is added to Radarr, and it may be missing or incorrect at that time. If you instead add it in the filename, the IMDb ID will be freshly pulled for any download or upgrade. Another potential negative of using it in the folder is that folder renames are complex, lengthy, and potentially destructive in Radarr compared to file renames.
 

--- a/docs/Radarr/V3/Radarr-recommended-naming-scheme.md
+++ b/docs/Radarr/V3/Radarr-recommended-naming-scheme.md
@@ -24,6 +24,14 @@ RESULT:
 
 `The Movie Title (2010) Ultimate Extended Edition [imdb-tt0066921][Surround Sound x264][Bluray-1080p Proper][3D][HDR][10bit][x264][DTS 5.1]-EVOLVE`
 
+??? info "If you do Anime"
+
+    If you do Anime you might consider to add the `{MediaInfo AudioLanguages}` token to your naming scheme.
+
+    ```bash
+    {Movie CleanTitle} {(Release Year)} {Edition Tags} [imdb-{ImdbId}]{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRange]}[{Mediainfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}{-Release Group}
+    ```
+
 ### Minimal details + the irreplaceable data
 
 This naming scheme is made to be compatible with the [New Plex Agent](https://forums.plex.tv/t/new-plex-media-server-movie-scanner-and-agent-preview/593269/517) that now support IMDB and TMDB IDs in file names, if you don't need it or want it just remove `[imdb-{ImdbId}]`

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Everything here you use on your own risk I won't be hold responsible if somethin
 
     ### Buy me a coffee
 
-    Buy me a coffee (paypal with subscription option and donator status on discord):
+    Buy me a coffee (paypal with subscription/membership option and Sponsor role on discord)
 
     <a href="https://www.buymeacoffee.com/TRaSH" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,9 +39,11 @@ Everything here you use on your own risk I won't be hold responsible if somethin
 
 ------
 
-## Buy me a coffee
+## Want to Buy me a coffee
 
 ??? abstract "CLICK HERE FOR THE OPTIONS HOW TO BUY ME A COFFEE"
+
+    ### Buy me a coffee
 
     Buy me a coffee (paypal with subscription option and donator status on discord):
 


### PR DESCRIPTION
```yml
Updated: Collection of Custom Formats for Radarr V3
- Fixed: FraMeSToR Custom Format so it scores correctly and doesn't get double counted
- Renamed: HDR (FraMeSToR) to  HDR (indeterminate), to be consistent and feature proof
- Changed: Anime-Dual Audio to recornized dual audio better+other fixes
```
thnx to @jyggen#1337 for the help with the `HDR (indeterminate)`
```yml
Updated: Radarr Recommended naming scheme
- Added: info to add {MediaInfo AudioLanguages} token if you do anime
- Added: info about Radarr now supports iMDb ID and TMDb ID in the folder name.
```
thnx to @DarkKnight#2447  for reporting `{MediaInfo AudioLanguages}` token if you do anime
```yml
Updated: How To Set Up Hardlinks and Atomic-Moves
- Changed: order of the synology warning
```