### PR TITLE
Golden rule formatting fix

### DIFF
--- a/docs/Misc/x265-4k.md
+++ b/docs/Misc/x265-4k.md
@@ -25,7 +25,7 @@ It's a shame that most x265 groups microsize the releases or use the x264 as sou
 
 ### Golden Rule
 
-I created my own golden rule.
+That's why I created my own golden rule.
 
 - 720/1080p => x264
 - 2160p/4k => x265
@@ -33,7 +33,7 @@ I created my own golden rule.
 #### How to accomplish the Golden Rule
 
 - For Sonarr check [HERE](/Sonarr/V3/Sonarr-Release-Profile-RegEx/#golden-rule){:target="_blank" rel="noopener noreferrer"}
-- For Radarr check [HERE](/Radarr/V3/Collection-of-Custom-Formats-for-RadarrV3/#7201080p-no-x265){:target="_blank" rel="noopener noreferrer"}
+- For Radarr check [HERE](/Radarr/V3/Radarr-collection-of-custom-formats/#7201080p-no-x265){:target="_blank" rel="noopener noreferrer"}
 
 ## Some extra info about 4K/X265
 

--- a/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
@@ -2546,7 +2546,7 @@ You will need to add the following to your new Custom Format when created in you
 
 It's a shame that most x265 groups microsize the releases or use the x264 as source what results in low quality releases. And the few groups that do use the correct source suffer from it.
 
-So I created my own golden rule.
+That's why I created my own golden rule.
 
 - 720/1080p => x264
 - 2160p/4k => x265
@@ -2901,7 +2901,7 @@ x265 is a *free software library* and *application* for encoding video streams i
 
 It's a shame that most x265 groups microsize the releases or use the x264 as source what results in low quality releases. And the few groups that do use the correct source suffer from it.
 
-So I created my own golden rule.
+That's why I created my own golden rule.
 
 - 720/1080p => x264
 - 2160p/4k => x265

--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx.md
@@ -203,7 +203,7 @@ Add this to your `Must not contain (2)`
 
     It's a shame that most x265 groups microsize the releases or use the x264 as source what results in low quality releases. And the few groups that do use the correct source suffer from it.
 
-    So I created my own golden rule.
+    That's why  I created my own golden rule.
 
     - 720/1080p => x264
     - 2160p/4k => x265


### PR DESCRIPTION
```yml
Updated: Misc - x265-4k
- Changed: Golden Rule Formatting
- Changed: redirect from old URL link to new URL link for Radarr-collection-of-custom-formats
Updated: Radarr - Collection of Custom Formats
- Changed: Golden Rule Formatting
Updated: Sonarr - Release Profile RegEx (WEB-DL)
- Changed: Golden Rule Formatting
```