### PR TITLE
Updated: Sonarr - Quality Settings (File Size)

### DIFF
--- a/docs/Sonarr/V3/Sonarr-Quality-Settings-File-Size.md
+++ b/docs/Sonarr/V3/Sonarr-Quality-Settings-File-Size.md
@@ -38,11 +38,11 @@ I only do WEB-DL my self for TV shows because in my opinion WEB-DL is the sweet 
 
 | Quality            | Minimum | Maximum |
 | ------------------ | ------- | ------- |
-| HDTV-720p          | 17.9    | 67.5    |
+| HDTV-720p          | 15      | 67.5    |
 | HDTV-1080p         | 20      | 137.3   |
 | WEBRip-720p        | 20      | 137.3   |
 | WEBDL-720p         | 20      | 137.3   |
-| Bluray-720p        | 34.9    | 137.3   |
+| Bluray-720p        | 25      | 137.3   |
 | WEBRip-1080p       | 22      | 137.3   |
 | WEBDL-1080p        | 22      | 137.3   |
 | Bluray-1080p       | 50.4    | 227     |


### PR DESCRIPTION
```yml
- Changed: HDTV-720p lowered from 17.9 to 15 (for Riverdale and This is Us episodes)
- Changed: Bluray-720p lowered from 34.9 to 25 (for South Park episodes)
```