### PR TITLE
Rename remux qualities to match Radarr

### DIFF
--- a/docs/Radarr/V3/Radarr-Quality-Settings-File-Size.md
+++ b/docs/Radarr/V3/Radarr-Quality-Settings-File-Size.md
@@ -38,22 +38,22 @@ This Quality Settings has been created and tested with info I got from others, a
 
 ## Radarr Quality Definitions
 
-| Quality            | Minimum | Maximum |
-| ------------------ | ------- | ------- |
-| HDTV-720p          | 17.1    | 400     |
-| WEBDL-720p         | 17.1    | 400     |
-| WEBRip-720p        | 17.1    | 400     |
-| Bluray-720p        | 25.7    | 400     |
-| HDTV-1080p         | 33.7    | 400     |
-| WEBDL-1080p        | 33.7    | 400     |
-| WEBRip-1080p       | 33.7    | 400     |
-| Bluray-1080p       | 50.8    | 400     |
-| Bluray-1080p Remux | 170.8   | 400     |
-| HDTV-2160p         | 85      | 400     |
-| WEBDL-2160p        | 85      | 400     |
-| WEBRip-2160p       | 85      | 400     |
-| Bluray-2160p       | 102     | 400     |
-| Bluray-2160p Remux | 221.5   | 400     |
+| Quality      | Minimum | Maximum |
+| ------------ | ------- | ------- |
+| HDTV-720p    | 17.1    | 400     |
+| WEBDL-720p   | 17.1    | 400     |
+| WEBRip-720p  | 17.1    | 400     |
+| Bluray-720p  | 25.7    | 400     |
+| HDTV-1080p   | 33.7    | 400     |
+| WEBDL-1080p  | 33.7    | 400     |
+| WEBRip-1080p | 33.7    | 400     |
+| Bluray-1080p | 50.8    | 400     |
+| Remux-1080p  | 170.8   | 400     |
+| HDTV-2160p   | 85      | 400     |
+| WEBDL-2160p  | 85      | 400     |
+| WEBRip-2160p | 85      | 400     |
+| Bluray-2160p | 102     | 400     |
+| Remux-2160p  | 221.5   | 400     |
 
 !!! note
     The reason why you don't see the preferred score in the Table is because we want max quality anyway so as high as possible.


### PR DESCRIPTION
Certain remux quality names did not exactly match the names used in
Radarr. Modified names are:

* `Bluray-1080p Remux` -> `Remux-1080p`
* `Bluray-2160p Remux` -> `Remux-2160p`

Markdown table formatted for styling as needed after the above changes.