### PR TITLE
Maintenance release 20210327

### DIFF
--- a/docs/Radarr/V3/Radarr-Quality-Settings-File-Size.md
+++ b/docs/Radarr/V3/Radarr-Quality-Settings-File-Size.md
@@ -48,7 +48,7 @@ This Quality Settings has been created and tested with info I got from others, a
 | WEBDL-1080p  | 33.7    | 400     |
 | WEBRip-1080p | 33.7    | 400     |
 | Bluray-1080p | 50.8    | 400     |
-| Remux-1080p  | 170.8   | 400     |
+| Remux-1080p  | 136.8   | 400     |
 | HDTV-2160p   | 85      | 400     |
 | WEBDL-2160p  | 85      | 400     |
 | WEBRip-2160p | 85      | 400     |

--- a/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
@@ -2738,12 +2738,12 @@ That's why I created my own golden rule.
         "name": "3D",
         "includeCustomFormatWhenRenaming": false,
         "specifications": [{
-            "name": "3d|sbs|half-ou",
+            "name": "3D",
             "implementation": "ReleaseTitleSpecification",
             "negate": false,
             "required": true,
             "fields": {
-                "value": "3d|sbs|half.?ou"
+                "value": "\\b3d\\b|\\bsbs\\b|half[ .]ou"
             }
         }]
     }


### PR DESCRIPTION
```yml
Updated: Radarr - Quality Settings (File Size)
- Changed: Lowered Remux-1080p minimum from [170.8](10/15/20GB) to [136.8](8/12/16GB)
Updated: Radarr - Collection of Custom Formats
- Fixed: 3D - Solved issue with recornizing 3D in obfuscated file names + cleanup regex
```