### PR TITLE
Update Basic DTS / Not DTS-HD regex

### DIFF
--- a/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/V3/Radarr-collection-of-custom-formats.md
@@ -1212,7 +1212,7 @@ I also made 2 guides related to this one.
                 "negate": true,
                 "required": true,
                 "fields": {
-                    "value": "dts.?(hd|ma|es|hi)"
+                    "value": "dts.?(hd|ma|es|hi|hr)"
                 }
             },
             {


### PR DESCRIPTION
Updates the Not DTS-HD regex to match against DTS-HD HRA, stops releases with DTS-HD HRA from being matched against both DTS and DTS-HD HRA custom formats.