### PR TITLE
Optional suggestions for preferring Dub releases when no dual-audio available 

### DIFF
--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx-Anime.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx-Anime.md
@@ -207,7 +207,7 @@ The reason most of these are added is due to their shitty quality or just in gen
 
 !!! important
 
-    If you would like `dub` releases then remove the last 2 lines and do not add them.
+    If you would like `dub` releases then remove the last 2 lines and do not add them to Must Not Contain. Instead follow the optional suggestion found below. 
 
 ```bash
 /(\[EMBER\]|-EMBER\b|DaddySubs)/i,
@@ -250,6 +250,28 @@ Add this to your Preferred with a score of **[501]**
 
 !!! important
     These next few are optional but they are here to move releases up over lower tiers of `1080/720p` or `WEB-DL/Blu-Ray`. Will add another note like this to end the optional section.
+
+---
+
+If you prefer a Dub relase when no Dual-Audio is available add this to your Preferred with a score of **[301]**
+
+!!! note
+    Ensure you did not add this in Must Not Contain above.
+
+```bash
+/((funi|eng(lish)?)_?dub|\bdub(bed)?\b)/i
+```
+
+---
+
+If you prefer a Dub release when no Dual-Audio is available add this to your Preferred with a score of **[100]**
+
+!!! note
+    Ensure you did not add this in Must Not Contain above.
+
+```bash
+/(Golumpa|torenter69|KamiFS|KaiDubs)/i
+```
 
 ---
 

--- a/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx-Anime.md
+++ b/docs/Sonarr/V3/Sonarr-Release-Profile-RegEx-Anime.md
@@ -207,7 +207,7 @@ The reason most of these are added is due to their shitty quality or just in gen
 
 !!! important
 
-    If you would like `dub` releases then remove the last 2 lines and do not add them to Must Not Contain. Instead follow the optional suggestion found below. 
+    If you would like `dub` releases then remove the last 2 lines and do not add them to Must Not Contain. Instead follow the optional suggestion found below.
 
 ```bash
 /(\[EMBER\]|-EMBER\b|DaddySubs)/i,


### PR DESCRIPTION
Apologies if I've done something incorrect here, first time I've done anything other then open an Issue on GitHub. 

I noticed I was still getting Erai-raws releases when a dub was available but no dual audio option was. I had followed the initial instruction to not add the last two lines to the Must Not Contain but they were still being outscored due to those lines not being added anywhere in preferred. This was my solution. Dub releases appear to be getting a score of 406 now if they match both of the changes I made plus the +5 score in your optional section, so they're not outscoring a dual audio release with 501 or any of the ones with higher scores, which I assume are likely to be dual-audio if available. Not sure if the scoring should be modified. 