### PR TITLE
Removed extra heading

### DIFF
--- a/docs/Bazarr/scripts/2to3-language-code/2to3_language_code.sh
+++ b/docs/Bazarr/scripts/2to3-language-code/2to3_language_code.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-mv "{{subtitles}}" "{{directory}}/{{episode_name}}.{{subtitles_language_code3}}.srt"
-
-exit

--- a/docs/Bazarr/scripts/2to3-language-code/README.md
+++ b/docs/Bazarr/scripts/2to3-language-code/README.md
@@ -1,7 +1,0 @@
-# 2to3-language-code
-
->Title:         [2to3-language-code.sh](https://raw.githubusercontent.com/TRaSH-/Tutorials-FAQ/master/docs/Bazarr/scripts/2to3-language-code/2to3_language_code.sh){:target="_blank" rel="noopener noreferrer"} | Author(s):     ???
-
-## Description: Changes the 2 iso code to 3 iso code
-
-Changes the 2 iso language code to 3 iso language  code.


### PR DESCRIPTION
The heading https://trash-guides.info/Bazarr/scripts/2to3-language-code/ doesn't contain anything useful and can be removed.
The script is currently located at https://trash-guides.info/Bazarr/scripts/