### PR TITLE
Let dependabot handle versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-python@v2.2.2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.x
       - run: pip install -r docs/requirements.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: editorconfig-checker
         run: |
           docker run --rm -v ${GITHUB_WORKSPACE}:/check mstruebing/editorconfig-checker
@@ -14,7 +14,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: markdownlint
         run: |
           find ~+ ${github_workspace} -name '*.md' | xargs docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} markdownlint/markdownlint -r ~MD013,~MD033,~MD034,~MD046,~MD002
@@ -22,7 +22,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v2
       - name: yamllint
         run: |
           find ~+ ${github_workspace} -name '*.yaml' -o -name '*.yml' | xargs docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} peterdavehello/yamllint yamllint -d '{extends: default, rules: {document-start: {present: false}, line-length: disable}}'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
-mkdocs>=1.1.2
-mkdocs-material>=6.1.0
-pymdown-extensions>=3.3.2
-mkdocs-macros-plugin>=0.4.18
-mkdocs-awesome-pages-plugin>=2.4.0
-mkdocs-redirects>=1.0.1
-mkdocs-git-revision-date-localized-plugin>=0.7.3
+mkdocs==1.1.2
+mkdocs-material==6.1.0
+pymdown-extensions==3.3.2
+mkdocs-macros-plugin==0.4.18
+mkdocs-awesome-pages-plugin==2.4.0
+mkdocs-redirects==1.0.1
+mkdocs-git-revision-date-localized-plugin==0.7.3
 git+git://github.com/g-provost/lightgallery-markdown#egg=lightgallery


### PR DESCRIPTION
This will trigger a number of dependabot pull requests that will need to be merged.

Going forward, version changes should  be handled by dependabot PRs, and it should be more obvious when they happen.

Currently in the requirements.txt file where `>=` is used, any version of the dependency that is greater than or equal to the specified version can be used and dependabot does not make PRs to bump those versions. The desired behavior is to use an exact version with `==` and let dependabot PR new versions. This also makes rollback easier when an issue occurs (see note below about upcoming mkdocs version bump).

UPCOMING MKDOCS VERSION BUMP:

Version 1.2 of mkdocs seems to have an issue with pushing to the `gh-pages` branch. When dependabot creates the PR for this update, I would advise to not merge it. I'll follow up if I'm able to confirm a fix.