### PR TITLE
Update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-git+git://github.com/g-provost/lightgallery-markdown#egg=lightgallery
-git+https://github.com/squidfunk/mkdocs-material
+git+https://github.com/fralau/mkdocs_macros_plugin@v0.5.12#egg=mkdocs-macros-plugin
+git+https://github.com/g-provost/lightgallery-markdown@v0.5#egg=lightgallery
 markdown==3.3.4
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-git-revision-date-localized-plugin==0.9.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 git+git://github.com/g-provost/lightgallery-markdown#egg=lightgallery
+git+https://github.com/squidfunk/mkdocs-material
 markdown==3.3.4
 mkdocs-awesome-pages-plugin==2.5.0
 mkdocs-git-revision-date-localized-plugin==0.9.2
-mkdocs-macros-plugin==0.5.5
 mkdocs-material-extensions==1.0.1
 mkdocs-material==7.1.8
 mkdocs-minify-plugin==0.4.0


### PR DESCRIPTION
Install mkdocs-macros-plugin from git since they have not updated https://pypi.org/project/mkdocs-macros-plugin/#history since 0.5.5 and mkdocs 1.2 needs a fix that was pushed in https://github.com/fralau/mkdocs_macros_plugin/commit/4bf847b3460471ee9cf2559cd5562954f378fe3b