### PR TITLE
Add Sonarr JSON and generator routine (local branch).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ venv/
 mkdocs-dev-server.bat
 /docs/Notifiarr/preview.bat
 /docs/Notifiarr/Integrations/_TEMPLATE.md
+__pycache__
+/site
+generated
+.DS_*
+._*

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -77,88 +77,10 @@ The Number between the **[**brackets**]** are the scores the release name will g
 
 ## First Release Profile
 
-<!-- [trash_id: a0e7774a471e041d4f1111e0690244d0] -->
 !!! important
     We're going to make use of 2 separate release profiles.
 
-### Release Sources (Streaming Service)
-
-!!! note
-
-    Also check mark `Include Preferred when Renaming` and add `{Preferred Words}` to your renaming scheme when you get download loop issues!!!
-
-    What it does:
-
-    When enabled the block with the [Release Source (Streaming Service)](#release-source-streaming-service) in it are then added to the file name which fixes any loops due to Sonarr seeing a new NF rip when an AMZN rip is found.
-    Probably doesn’t happen if cutoff is met, but for anything that is unmet or any forced searches it results in a loop because NF is not in Sonarr’s copy so it upgrades, and loops.
-
-    Enabling the include in preferred words for AMZN and adding that to the file name fixes that.
-
-    Example of a naming scheme for series:
-
-    Can be found [HERE](/Sonarr/Sonarr-recommended-naming-scheme/){:target="_blank" rel="noopener noreferrer"}
-
-Add this to your `Preferred (3)` with a score of [100]
-
-```bash
-/\b(amzn|amazon)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(atvp|aptv)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(hmax)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-Add this to your `Preferred (3)` with a score of [95]
-
-```bash
-/\b(sho)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-Add this to your `Preferred (3)` with a score of [90]
-
-```bash
-/\b(dsnp|dsny|disney)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(nf|netflix)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(qibi)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-Add this to your `Preferred (3)` with a score of [85]
-
-```bash
-/\b(hulu)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(pcok)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-Add this to your `Preferred (3)` with a score of [75]
-
-```bash
-/\b(dcu)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(hbo)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(red)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
-```bash
-/\b(it)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
+--8<-- "docs/Sonarr/generated/streaming.mdt"
 
 ??? success "example"
 
@@ -176,17 +98,7 @@ Add this to your `Preferred (3)` with a score of [75]
 
 ## Second Release Profile
 
-<!-- [trash_id: 37cf8cdd57c8fb4a8b68f36e00e40de2] -->
-!!! warning
-    DO NOT Check mark `Include Preferred when Renaming`
-
-### Golden rule
-
-Add this to your `Must not contain (2)`
-
-```bash
-/(?=(1080|720)).*((x|h)[ ._-]?265|hevc)/i
-```
+--8<-- "docs/Sonarr/generated/golden-rule.mdt"
 
 ??? success "example"
 
@@ -224,78 +136,7 @@ Add this to your `Must not contain (2)`
 
 ------
 
-### P2P Groups + Repack/Proper
-
-Add this to your `Preferred (3)` with a score of [180]
-The reason why this one get's such a high score is because it's the only quality scene group that exist (till now) and scene groups don't add the [Release Sources (Streaming Service)](#release-sources-streaming-service) to their release name so they don't get the extra point of the release source regex.
-
-```bash
-/(-deflate|-inflate)\b/i
-```
-
-Add this to your `Preferred (3)` with a score of [150]
-
-```bash
-/(-AJP69|-BTN|-CasStudio|-CtrlHD|-KiNGS)\b/i
-```
-
-```bash
-/(-monkee|-NTb|-NTG|-QOQ|-RTN)\b/i
-```
-
-```bash
-/(-TOMMY|-ViSUM|-T6D)\b/i
-```
-
-Add this to your `Preferred (3)` with a score of [125]
-
-```bash
-/(-BTW|-Chotab|-CiT|-DEEP|-iJP|-iT00NZ)\b/i
-```
-
-```bash
-/(-LAZY|-NYH|-SA89|-SIGMA|-TEPES|-TVSmash)\b/i
-```
-
-```bash
-/(-SDCC|-iKA|-iJP|-Cinefeel|-SPiRiT|-FC)\b/i
-```
-
-```bash
-/(-JETIX|-Coo7|-WELP|-KiMCHI|-BLUTONiUM)\b/i
-```
-
-```bash
-/(-orbitron|-ETHiCS|-RTFM|-PSiG|-MZABI)\b/i
-```
-
-```bash
-/(-ROCCaT|3cTWeB|playWEB)\b/i
-```
-
-Add this to your `Preferred (3)` with a score of [100]
-
-```bash
-/(-ViSiON|-FLUX)\b/i
-```
-
-Add this to your `Preferred (3)` with a score of [12]
-
-```bash
-/(repack3)/i
-```
-
-Add this to your `Preferred (3)` with a score of [11]
-
-```bash
-/(repack2)/i
-```
-
-Add this to your `Preferred (3)` with a score of [10]
-
-```bash
-/\b(repack|proper)\b/i
-```
+--8<-- "docs/Sonarr/generated/p2p.mdt"
 
 ??? success "example"
 
@@ -311,17 +152,7 @@ Add this to your `Preferred (3)` with a score of [10]
 
 ------
 
-### Low Quality Groups
-
-Add this to your `Preferred (3)` with a score of [-100]
-
-```bash
-/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS)\b/i
-```
-
-```bash
-/(-VIDEOHOLE|nhanc3)\b/i
-```
+--8<-- "docs/Sonarr/generated/low-quality.mdt"
 
 ??? success "example"
 

--- a/docs/json/sonarr/generator.py
+++ b/docs/json/sonarr/generator.py
@@ -1,0 +1,68 @@
+import os
+import jinja2
+import json
+import pathlib
+
+# This script generates markdown files for Sonarr from the json files in this same folder.
+# This is executed by `mkdocs` and the `mkdocs-simple-hooks` plugin (invoked from mkdocs.yml).
+
+source_dir="docs/json/sonarr"
+output_dir="docs/Sonarr/generated/"
+
+def sonarr_markdown(*args, **kwargs):
+    pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    for js in os.listdir(source_dir):
+        if js.endswith(".json"):
+            with open(os.path.join(source_dir, js)) as json_file:
+                data = json.load(json_file)
+
+                template = jinja2.Template("""<!-- markdownlint-disable-next-line MD041 -->
+### {{ obj.name }}
+{% if obj.note is defined %}
+{{ obj.note }}
+{% endif %}
+{%- for i in obj.mustContain %}
+Add this to your `Must contain (1)`
+```bash
+{{ i }}
+```
+{% endfor %}
+{%- for i in obj.mustNotContain %}
+Add this to your `Must not contain (2)`
+```bash
+{{ i }}
+```
+{% endfor %}
+{%- for i in obj.preferred %}
+{% if i.note is defined %}
+{{ i.note | indent(4) }}
+{% endif %}
+Add this to your `Preferred (3)` with a score of [{{ i.score }}]
+{%- for term in i.terms %}
+<!-- markdownlint-disable-next-line MD046 -->
+```bash
+{{ term }}
+```
+{% endfor %}
+{%- endfor %}
+{%- if obj.optional is defined %}
+#### Optional (this code was not well tested since the site does not use it)
+* Must contain: `{{ (obj.optional.mustContain | default([])) | join(", ") }}`
+* Must not contain: `{{ (obj.optional.mustNotContain | default([])) | join(", ") }}`
+{%- for i in obj.optional.preferred %}
+* Score: {{ i.score }}
+{% if i.note is defined %}
+{{ i.note | indent(4) }}
+{% endif %}
+{%- for term in i.terms %}
+<!-- markdownlint-disable-next-line MD046 -->
+```bash
+{{ term }}
+```
+{% endfor %}
+{%- endfor %}
+{%- endif %}
+""")
+                template.stream(obj=data).dump(
+                    f"{output_dir}{js.split('.')[0]}.mdt")

--- a/docs/json/sonarr/golden-rule.json
+++ b/docs/json/sonarr/golden-rule.json
@@ -1,0 +1,11 @@
+{
+  "name": "Golden rule",
+  "_trash_id": "37cf8cdd57c8fb4a8b68f36e00e40de2",
+  "mustContain": [],
+  "mustNotContain": [
+    "/(?=(1080|720)).*((x|h)[ ._-]?265|hevc)/i"
+  ],
+  "includePreferredWhenRenaming": false,
+  "preferred": [],
+  "note": "!!! warning\n    DO NOT Check mark `Include Preferred when Renaming`"
+}

--- a/docs/json/sonarr/low-quality.json
+++ b/docs/json/sonarr/low-quality.json
@@ -1,0 +1,16 @@
+{
+  "name": "Low Quality Groups",
+  "_trash_id": "",
+  "includePreferredWhenRenaming": true,
+  "mustContain": [],
+  "mustNotContain": [],
+  "preferred": [
+    {
+      "score": -100,
+      "terms": [
+        "/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS)\\b/i",
+        "/(-VIDEOHOLE|nhanc3)\\b/i"
+      ]
+    }
+  ]
+}

--- a/docs/json/sonarr/p2p.json
+++ b/docs/json/sonarr/p2p.json
@@ -1,0 +1,59 @@
+{
+  "name": "P2P Groups + Repack/Proper",
+  "_trash_id": "",
+  "mustContain": [],
+  "mustNotContain": [],
+  "includePreferredWhenRenaming": true,
+  "preferred": [
+    {
+      "score": 180,
+      "note": "The reason why this one get's such a high score is because it's the only quality scene group that exist (till now) and scene groups don't add the [Release Sources (Streaming Service)](#release-sources-streaming-service) to their release name so they don't get the extra point of the release source regex.",
+      "terms": [
+        "/(-deflate|-inflate)\\b/i"
+      ]
+    },
+    {
+      "score": 150,
+      "terms": [
+        "/(-AJP69|-BTN|-CasStudio|-CtrlHD|-KiNGS)\\b/i",
+        "/(-monkee|-NTb|-NTG|-QOQ|-RTN)\\b/i",
+        "/(-TOMMY|-ViSUM|-T6D)\\b/i"
+      ]
+    },
+    {
+      "score": 125,
+      "terms": [
+        "/(-BTW|-Chotab|-CiT|-DEEP|-iJP|-iT00NZ)\\b/i",
+        "/(-LAZY|-NYH|-SA89|-SIGMA|-TEPES|-TVSmash)\\b/i",
+        "/(-SDCC|-iKA|-iJP|-Cinefeel|-SPiRiT|-FC)\\b/i",
+        "/(-JETIX|-Coo7|-WELP|-KiMCHI|-BLUTONiUM)\\b/i",
+        "/(-orbitron|-ETHiCS|-RTFM|-PSiG|-MZABI)\\b/i",
+        "/(-ROCCaT)\\b/i"
+      ]
+    },
+    {
+      "score": 100,
+      "terms": [
+        "/(-ViSiON|-FLUX)\\b/i"
+      ]
+    },
+    {
+      "score": 12,
+      "terms": [
+        "/(repack3)/i"
+      ]
+    },
+    {
+      "score": 11,
+      "terms": [
+        "/(repack2)/i"
+      ]
+    },
+    {
+      "score": 10,
+      "terms": [
+        "/\\b(repack|proper)\\b/i"
+      ]
+    }
+  ]
+}

--- a/docs/json/sonarr/streaming.json
+++ b/docs/json/sonarr/streaming.json
@@ -1,0 +1,48 @@
+{
+  "name": "Release Sources (Streaming Service)",
+  "_trash_id": "a0e7774a471e041d4f1111e0690244d0",
+  "mustContain": [],
+  "mustNotContain": [],
+  "includePreferredWhenRenaming": true,
+  "note": "!!! note\n    Also check mark `Include Preferred when Renaming` and add `{Preferred Words}` to your renaming scheme when you get download loop issues!!!\n    \n    What it does:\n    \n    When enabled the block with the [Release Source (Streaming Service)](#release-source-streaming-service) in it are then added to the file name which fixes any loops due to Sonarr seeing a new NF rip when an AMZN rip is found.\n    Probably doesn’t happen if cutoff is met, but for anything that is unmet or any forced searches it results in a loop because NF is not in Sonarr’s copy so it upgrades, and loops.\n    \n    Enabling the include in preferred words for AMZN and adding that to the file name fixes that.\n    \n    Example of a naming scheme for series can be found [HERE](/Sonarr/Sonarr-recommended-naming-scheme/){:target=\"_blank\" rel=\"noopener noreferrer\"}",
+  "preferred": [
+    {
+      "score": 100,
+      "terms": [
+        "/\\b(amzn|amazon)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(atvp|aptv)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(hmax)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 95,
+      "terms": [
+        "/\\b(sho)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 90,
+      "terms": [
+        "/\\b(dsnp|dsny|disney)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(nf|netflix)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(qibi)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 85,
+      "terms": [
+        "/\\b(hulu)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(pcok)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 75,
+      "terms": [
+        "/\\b(dcu)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(hbo)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(red)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(it)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    }
+  ]
+}

--- a/docs/json/sonarr/test.json
+++ b/docs/json/sonarr/test.json
@@ -1,0 +1,49 @@
+{
+    "name": "Release Sources (Streaming Service)",
+    "includePreferredWhenRenaming": true,
+    "mustContain": [
+        "one",
+        "two"
+    ],
+    "mustNotContain": [
+        "three",
+        "four"
+    ],
+    "preferred": [
+        {
+            "score": 100,
+            "terms": [
+                "/\\b(amzn|amazon)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+                "/\\b(atvp|aptv)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+            ]
+        },
+        {
+            "score": 95,
+            "terms": [
+                "/\\b(sho)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+            ]
+        },
+        {
+            "score": 90,
+            "terms": [
+                "/\\b(dsnp|dsny|disney)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+            ]
+        }
+    ],
+    "optional": {
+        "mustContains": [
+            "five"
+        ],
+        "mustNotContain": [
+            "six"
+        ],
+        "preferred": [
+            {
+                "score": -1000,
+                "terms": [
+                    "seven"
+                ]
+            }
+        ]
+    }
+}

--- a/docs/json/sonarr/test.json
+++ b/docs/json/sonarr/test.json
@@ -1,49 +1,49 @@
 {
-    "name": "Release Sources (Streaming Service)",
-    "includePreferredWhenRenaming": true,
+  "name": "This is just a test file",
+  "includePreferredWhenRenaming": true,
+  "mustContain": [
+    "EN",
+    "FR"
+  ],
+  "mustNotContain": [
+    "ES",
+    "GE"
+  ],
+  "preferred": [
+    {
+      "score": 100,
+      "terms": [
+        "/\\b(amzn|amazon)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(atvp|aptv)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 95,
+      "terms": [
+        "/\\b(sho)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    },
+    {
+      "score": 90,
+      "terms": [
+        "/\\b(dsnp|dsny|disney)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+      ]
+    }
+  ],
+  "optional": {
     "mustContain": [
-        "one",
-        "two"
+      "EN"
     ],
     "mustNotContain": [
-        "three",
-        "four"
+      "ES"
     ],
     "preferred": [
-        {
-            "score": 100,
-            "terms": [
-                "/\\b(amzn|amazon)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-                "/\\b(atvp|aptv)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
-            ]
-        },
-        {
-            "score": 95,
-            "terms": [
-                "/\\b(sho)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
-            ]
-        },
-        {
-            "score": 90,
-            "terms": [
-                "/\\b(dsnp|dsny|disney)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
-            ]
-        }
-    ],
-    "optional": {
-        "mustContains": [
-            "five"
-        ],
-        "mustNotContain": [
-            "six"
-        ],
-        "preferred": [
-            {
-                "score": -1000,
-                "terms": [
-                    "seven"
-                ]
-            }
+      {
+        "score": -1000,
+        "terms": [
+          "/English/i"
         ]
-    }
+      }
+    ]
+  }
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ mkdocs-redirects==1.0.3
 mkdocs==1.2.1
 pygments==2.9.0
 pymdown-extensions==8.2
+mkdocs-simple-hooks==0.1.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ markdown_extensions:
 
 plugins:
   - search
+  - mkdocs-simple-hooks:
+      hooks:
+        on_pre_build: "docs.json.sonarr.generator:sonarr_markdown"
   - git-revision-date-localized:
       type: datetime
       locale: en


### PR DESCRIPTION
Replaced #279. (see comments there)

This contribution converts the markdown-esq Sonarr profiles into json files. A small python generator script is included to turn the JSON back into markdown. The code and idea was taken from @Roxedus  in [this commit](https://github.com/TRaSH-/Guides/compare/master...Roxedus:generator?diff=split). The "new" page looks almost identical to the previous. There are two specific ordering changes, explained in review comments.

To build the new templates just run `mkdocs build`. The templates are generated into `docs/Sonarr/generated` but they do not need to be committed. They are re-created every time `mkdocs` builds/deploys.

Please let me know if you have any questions!

- _Note1: Two of the new json files do not have a `trash_id`. Let me know what they should be and I'll add them._
- _Note2: The `Optional` section was not tested or setup properly because it's not used. We can fix that if needed._