### PR TITLE
Update hdr-undefined.json

### DIFF
--- a/docs/json/radarr/hdr-undefined.json
+++ b/docs/json/radarr/hdr-undefined.json
@@ -5,12 +5,12 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "FraMeSToR",
+      "name": "Groups",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bFraMeSToR\\b"
+        "value": "\\b(FraMeSToR|HQMUX)\\b"
       }
     },
     {


### PR DESCRIPTION
```yml
Updated: Radarr - Collection of Custom Formats
- Updated: [HDR (undefined)] - Added HQMUX as group without HDR in their title even that they have HDR
```