### PR TITLE
Fix anime regex to match `Anime.Time`

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx-Anime.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx-Anime.md
@@ -564,7 +564,7 @@ Sub-Par Releases 2nd Tier (Re-encoded to crap or really small filesizes) (Sepera
 ```
 
 ```bash
-/(BakedFish|N[eo][wo]b[ ._-]?Subs|\bAnime Time\b)/i
+/(BakedFish|N[eo][wo]b[ ._-]?Subs|\bAnime[ .]Time\b)/i
 ```
 
 ```bash


### PR DESCRIPTION
Fixes the anime profile regex to match the `Anime Time` release group when the space is replaced by a period: `Anime.Time`