### PR TITLE
Radarr CF DDPA

### DIFF
--- a/docs/json/radarr/dd-atmos.json
+++ b/docs/json/radarr/dd-atmos.json
@@ -3,77 +3,78 @@
   "trash_score": "1800",
   "name": "DD+ ATMOS",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
-          "name": "Dolby Digital Plus",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "[^-]dd[p+]|eac3"
-          }
-      },
-      {
-          "name": "ATMOS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "\\bATMOS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not TrueHD",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "TrueHD"
-          }
-      },
-      {
-          "name": "Not DTS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDTS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Basic Dolby Digital ",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "(?<!e)ac3"
-          }
-      },
-      {
-          "name": "Not FLAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bFLAC(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not AAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bAAC(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not PCM",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\b(l?)PCM(\\b|\\d)"
-          }
+  "specifications": [
+    {
+      "name": "Dolby Digital Plus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "[^-]dd[p+]|eac3"
       }
+    },
+    {
+      "name": "ATMOS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(ATMOS|DDPA)(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not TrueHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "TrueHD"
+      }
+    },
+    {
+      "name": "Not DTS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bDTS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Basic Dolby Digital ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(?<!e)ac3"
+      }
+    },
+    {
+      "name": "Not FLAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bFLAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not AAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bAAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not PCM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(l?)PCM(\\b|\\d)"
+      }
+    }
   ]
 }

--- a/docs/json/radarr/dolby-digital-plus.json
+++ b/docs/json/radarr/dolby-digital-plus.json
@@ -9,7 +9,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "[^-]dd[p+]|eac3"
+              "value": "[^-]DD[P+](?!A)|eac3"
           }
       },
       {


### PR DESCRIPTION
Updated: [DD+ Atmos]
- Added: Support for DDPA recognizing

Updated: [DD+]
- Fixed: So it doesn't recognize DDPA
