### PR TITLE
Changed: GitHub Container Registry to Docker Hub until further notice

### DIFF
--- a/docs/Bazarr/index.md
+++ b/docs/Bazarr/index.md
@@ -12,7 +12,7 @@ Here you will find several scripts you can use with Bazarr
 - Docker: [hotio/bazarr:latest](https://hotio.dev/containers/bazarr/){:target="_blank" rel="noopener noreferrer"}
 
 ```bash
-ghcr.io/hotio/bazarr:latest
+hotio/bazarr:latest
 ```
 
 ## Dev = Bazarr Branch: development
@@ -25,5 +25,5 @@ ghcr.io/hotio/bazarr:latest
 - Docker: [hotio/bazarr:nightly](https://hotio.dev/containers/bazarr/){:target="_blank" rel="noopener noreferrer"}
 
 ```bash
-ghcr.io/hotio/bazarr:nightly
+hotio/bazarr:nightly
 ```

--- a/docs/Radarr/index.md
+++ b/docs/Radarr/index.md
@@ -12,5 +12,5 @@ Here you will find a collection of Radarr Guides I made.
 - Docker: [hotio/radarr:release](https://hub.docker.com/r/hotio/radarr){:target="_blank" rel="noopener noreferrer"}
 
 ```bash
-ghcr.io/hotio/radarr:release
+hotio/radarr:release
 ```

--- a/docs/Sonarr/index.md
+++ b/docs/Sonarr/index.md
@@ -12,5 +12,5 @@ Here you will find a collection of Sonarr Guides I made.
 - Docker: [hotio/sonarr:release](https://hub.docker.com/r/hotio/sonarr){:target="_blank" rel="noopener noreferrer"}
 
 ```bash
-ghcr.io/hotio/sonarr:release
+hotio/sonarr:release
 ```


### PR DESCRIPTION
- Changed: GitHub Container Registry to Docker Hub until further notice