### PR TITLE
Fixed: block EVOTGx Retagged releases for CF

### DIFF
--- a/docs/json/radarr/evo-no-webdl.json
+++ b/docs/json/radarr/evo-no-webdl.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bEVO\\b"
+        "value": "\\bEVO(TGX)?\\b"
       }
     },
     {


### PR DESCRIPTION
`No Time to Die 2021 1080p Bluray Atmos TrueHD 7 1 x264-EVOTGx-xpost`