### PR TITLE
Update uhd-webdv.json

### DIFF
--- a/docs/json/radarr/uhd-webdv.json
+++ b/docs/json/radarr/uhd-webdv.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "ac49fdbf6a662d380556f40ff4856f29",
-  "trash_score": "3000",
+  "trash_score": "2875",
   "name": "UHD (WEBDV)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [


### PR DESCRIPTION
Updated: [UHD (WEBDV)]
- Changed: Score from 3000 to 2875 so it prefers hybrid remuxes over webdv