### PR TITLE
Update hdr.json

### DIFF
--- a/docs/json/radarr/hdr.json
+++ b/docs/json/radarr/hdr.json
@@ -66,6 +66,15 @@
       "fields": {
         "value": "\\bSDR(\\b|\\d)"
       }
+    },
+    {
+      "name": "Not Groups",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(FraMeSToR|HQMUX)\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
- Added: Condition to ignore Groups that don't add normally HDR in their naming, but some indexers add/rename the release what could result in double scoring