### PR TITLE
Cf update 20220116

### DIFF
--- a/docs/json/radarr/4k-remaster.json
+++ b/docs/json/radarr/4k-remaster.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "eca37840c13c6ef2dd0262b141a5482f",
-  "trash_score": "190",
+  "trash_score": "25",
   "name": "4K Remaster",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/atmos-undefined.json
+++ b/docs/json/radarr/atmos-undefined.json
@@ -3,77 +3,87 @@
   "trash_score": "3000",
   "name": "ATMOS (undefined)",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
-          "name": "Dolby Digital Plus",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "[^-]dd[p+]|eac3"
-          }
-      },
-      {
-          "name": "ATMOS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "\\bATMOS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not TrueHD",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "TrueHD"
-          }
-      },
-      {
-          "name": "Not DTS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDTS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Basic Dolby Digital ",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "(?<!e)ac3"
-          }
-      },
-      {
-          "name": "Not FLAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bFLAC(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not AAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bAAC(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not PCM",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\b(l?)PCM(\\b|\\d)"
-          }
+  "specifications": [
+    {
+      "name": "Dolby Digital Plus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^-]dd[p+]|eac3"
       }
+    },
+    {
+      "name": "ATMOS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\bATMOS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not TrueHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "TrueHD"
+      }
+    },
+    {
+      "name": "Not DTS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bDTS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Basic Dolby Digital ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(?<!e)ac3"
+      }
+    },
+    {
+      "name": "Not FLAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bFLAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not AAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bAAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not PCM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(l?)PCM(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Groups (Atmos Only)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "W4NK3R|HQMUX"
+      }
+    }
   ]
 }

--- a/docs/json/radarr/criterion-collection.json
+++ b/docs/json/radarr/criterion-collection.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "e0c07d59beb37348e975a930d5e50319",
-  "trash_score": "170",
+  "trash_score": "25",
   "name": "Criterion Collection",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [{

--- a/docs/json/radarr/hdr-undefined.json
+++ b/docs/json/radarr/hdr-undefined.json
@@ -5,7 +5,7 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "Groups",
+      "name": "Groups (Missing HDR)",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,

--- a/docs/json/radarr/hdr.json
+++ b/docs/json/radarr/hdr.json
@@ -68,7 +68,7 @@
       }
     },
     {
-      "name": "Not Groups",
+      "name": "Not Groups (Missing HDR)",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,

--- a/docs/json/radarr/truehd-atmos.json
+++ b/docs/json/radarr/truehd-atmos.json
@@ -3,59 +3,60 @@
   "trash_score": "5000",
   "name": "TrueHD ATMOS",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
-          "name": "TrueHD",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "TrueHD"
-          }
-      },
-      {
-          "name": "ATMOS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "\\bATMOS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Dolby Digital Plus ",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "[^-]dd[p+]|eac3"
-          }
-      },
-      {
-          "name": "Not DTS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDTS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Basic Dolby Digital",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "(?<!e)ac3"
-          }
-      },
-      {
-          "name": "Not FLAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bFLAC(\\b|\\d)"
-          }
+  "specifications": [
+    {
+      "name": "TrueHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "TrueHD|W4NK3R|HQMUX"
       }
+    },
+    {
+      "name": "ATMOS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\bATMOS(\\b|\\d)|CtrlHD"
+      }
+    },
+    {
+      "name": "Not Dolby Digital Plus ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^-]dd[p+]|eac3"
+      }
+    },
+    {
+      "name": "Not DTS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bDTS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Basic Dolby Digital",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(?<!e)ac3"
+      }
+    },
+    {
+      "name": "Not FLAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bFLAC(\\b|\\d)"
+      }
+    }
   ]
 }

--- a/docs/json/radarr/truehd.json
+++ b/docs/json/radarr/truehd.json
@@ -3,59 +3,69 @@
   "trash_score": "2750",
   "name": "TrueHD",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
-          "name": "TrueHD",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "TrueHD"
-          }
-      },
-      {
-          "name": "ATMOS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bATMOS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Dolby Digital Plus",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "[^-]dd[p+]|eac3"
-          }
-      },
-      {
-          "name": "Not DTS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDTS(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not FLAC",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bFLAC(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Basic Dolby Digital",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "(?<!e)ac3"
-          }
+  "specifications": [
+    {
+      "name": "TrueHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "TrueHD"
       }
+    },
+    {
+      "name": "ATMOS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bATMOS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Dolby Digital Plus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "[^-]dd[p+]|eac3"
+      }
+    },
+    {
+      "name": "Not DTS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bDTS(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not FLAC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bFLAC(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not Basic Dolby Digital",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(?<!e)ac3"
+      }
+    },
+    {
+      "name": "Not Groups (TrueHD only)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "CtrlHD"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Updated: Radarr - Collection of Custom Formats
- Updated: CF `[4K Remaster]` Scores to the new scoring standard.
- Updated: CF `[Criterion Collection]` Scores to the new scoring standard.
- Fixed: CF `[TrueHD Atmos]` to recognize groups that only use Atmos/TrueHD in their release name.
- Fixed: CF `[ATMOS (undefined)]` to prevent double scoring with latest update of `[TrueHD Atmos]`.
- Fixed: CF `[TrueHD]` to prevent double scoring with latest update of `[TrueHD Atmos]`.
- Changed: CF `[HDR]` `[HDR (undefined)]`condition name.