### PR TITLE
add Remux to DoVi

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -442,7 +442,7 @@ Add this to your `Preferred (3)` with a score of [15]
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(HDR|HULU))(?=.*\b(DV|Dovi|Dolby[- .]Vision)\b).*/i
+/^(?!.*(HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]Vision)\b).*/i
 ```
 
 #### Optional Ignore the group -scene


### PR DESCRIPTION
Add Remux into the list of sources to pull DoVi. Found these GOT examples of DV BluRay remuxes.
 
![Screen Shot 2022-01-19 at 8 00 25 PM](https://user-images.githubusercontent.com/97920769/150270901-a33c7fb5-8680-4ff4-b2bb-5e974daf2e5d.png)
.