### PR TITLE
Maintenace release 20220121

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -111,10 +111,6 @@ Add this to your `Preferred (3)` with a score of [100]
 /\b(atvp|aptv)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
-```bash
-/\b(hmax|hbom)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
-```
-
 Add this to your `Preferred (3)` with a score of [95]
 
 ```bash
@@ -133,6 +129,10 @@ Add this to your `Preferred (3)` with a score of [90]
 
 ```bash
 /\b(qibi)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
+```bash
+/\b(hmax|hbom)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 Add this to your `Preferred (3)` with a score of [85]

--- a/docs/json/radarr/truehd-atmos.json
+++ b/docs/json/radarr/truehd-atmos.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bATMOS(\\b|\\d)|CtrlHD"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/truehd.json
+++ b/docs/json/radarr/truehd.json
@@ -64,7 +64,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "CtrlHD"
+        "value": "CtrlHD|W4NK3R"
       }
     }
   ]


### PR DESCRIPTION
Updated: Radarr - Collection of Custom Formats
- Fixed: CF [TrueHD Atmos] to recognize groups that only use Atmos/TrueHD in their release name.
- Fixed: CF [TrueHD] to prevent double scoring with latest update of [TrueHD Atmos].
Updated: Sonarr- Release Profile RegEx (WEB-DL)
- Changed: Scores HBO MAX (hmax|hbom).