### PR TITLE
Radarr Custom Format Collection 20220127

### DIFF
--- a/docs/Radarr/Radarr-setup-custom-formats.md
+++ b/docs/Radarr/Radarr-setup-custom-formats.md
@@ -186,7 +186,7 @@ For this Quality Profile we're going to make use of the following Custom Formats
     | Custom Format        | Score | LINK |
     | -------------------- | ----- | ---- |
     | HQ-WEBDL             | 1750  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-webdl){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | HQ-Remux             | 2000  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | HQ-Remux             | 1900  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
     | HQ                   |    0  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq){: .header-icons target=_blank rel="noopener noreferrer" } |
 
 Use the following main settings in your profile.
@@ -232,7 +232,7 @@ For this Quality Profile we're going to make use of the following Custom Formats
     | Custom Format        | Score | LINK |
     | -------------------- | ----- | ---- |
     | HQ-WEBDL             | 1750  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-webdl){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | HQ-Remux             | 2000  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | HQ-Remux             | 1900  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
     | HQ                   |    0  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq){: .header-icons target=_blank rel="noopener noreferrer" } |
 
 Use the following main settings in your profile.

--- a/docs/json/radarr/bhdstudio.json
+++ b/docs/json/radarr/bhdstudio.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "5153ec7413d9dae44e24275589b5e944",
-  "trash_score": "2000",
+  "trash_score": "1800",
   "name": "BHDStudio",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/hq-remux.json
+++ b/docs/json/radarr/hq-remux.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "403f3f6266b90439cacc1e07cae4dc2d",
-  "trash_score": "2000",
+  "trash_score": "1900",
   "name": "HQ-Remux",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/truehd-atmos.json
+++ b/docs/json/radarr/truehd-atmos.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ATMOS|CtrlHD|W4NK3R)(\\b|\\d)"
+        "value": "\\b(ATMOS|CtrlHD|W4NK3R|DON)(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/truehd.json
+++ b/docs/json/radarr/truehd.json
@@ -64,7 +64,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "CtrlHD|W4NK3R"
+        "value": "CtrlHD|W4NK3R|\\bDON\\b"
       }
     }
   ]

--- a/docs/json/radarr/uhd-hqmux.json
+++ b/docs/json/radarr/uhd-hqmux.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "96848626e1570c122aba8642fe2714a2",
-  "trash_score": "2250",
+  "trash_score": "2200",
   "name": "UHD (HQMUX)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/uhd-legi0n.json
+++ b/docs/json/radarr/uhd-legi0n.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "4da96773192a51cf96178212642ca3bb",
-  "trash_score": "2200",
+  "trash_score": "2100",
   "name": "UHD (LEGi0N)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/uhd-webdv.json
+++ b/docs/json/radarr/uhd-webdv.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "ac49fdbf6a662d380556f40ff4856f29",
-  "trash_score": "2150",
+  "trash_score": "1800",
   "name": "UHD (WEBDV)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/includes/cf/hq-source-group.md
+++ b/includes/cf/hq-source-group.md
@@ -2,5 +2,5 @@
     | Custom Format        | Score | LINK |
     | -------------------- | ----- | ---- |
     | HQ-WEBDL             | 1750  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-webdl){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | HQ-Remux             | 2000  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | HQ-Remux             | 1900  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
     | HQ                   | 1800  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq){: .header-icons target=_blank rel="noopener noreferrer" } |

--- a/includes/cf/hq4k.md
+++ b/includes/cf/hq4k.md
@@ -4,6 +4,6 @@
     | UHD (CtrlHD)         | 2300  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-ctrlhd.json){: .header-icons target=_blank rel="noopener noreferrer" } |
     | UHD (DON)            | 2300  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-don.json){: .header-icons target=_blank rel="noopener noreferrer" } |
     | UHD (W4NK3R)         | 2300  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-w4nk3r.json){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | UHD (HQMUX)          | 2250  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-hqmux.json){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | UHD (LEGi0N)         | 2200  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-legi0n.json){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | UHD (WEBDV)          | 2150  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-webdv.json){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | UHD (HQMUX)          | 2200  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-hqmux.json){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | UHD (LEGi0N)         | 2100  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-legi0n.json){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | UHD (WEBDV)          | 1800  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-webdv.json){: .header-icons target=_blank rel="noopener noreferrer" } |

--- a/includes/sqp/1-1-cf-scoring.md
+++ b/includes/sqp/1-1-cf-scoring.md
@@ -10,7 +10,7 @@
 ??? summary "BHDStudio - [CLICK TO EXPAND]"
     | Custom Format        | Score | LINK |
     | -------------------- | ----- | ---- |
-    | BHDStudio            | 2000  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/bhdstudio.json){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | BHDStudio            | 1800  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/bhdstudio.json){: .header-icons target=_blank rel="noopener noreferrer" } |
 
 ??? summary "Misc - [CLICK TO EXPAND]"
     | Custom Format        | Score | LINK |

--- a/includes/sqp/1-2-cf-scoring.md
+++ b/includes/sqp/1-2-cf-scoring.md
@@ -10,7 +10,7 @@
     | Custom Format        | Score | LINK |
     | -------------------- | ----- | ---- |
     | HQ-WEBDL             | 1750  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-webdl){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | HQ-Remux             | 2000  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | HQ-Remux             | 1900  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq-remux){: .header-icons target=_blank rel="noopener noreferrer" } |
     | HQ                   |    0  | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#hq){: .header-icons target=_blank rel="noopener noreferrer" } |
 
 --8<-- "includes/cf/hq4k.md"


### PR DESCRIPTION
Radarr Custom Format Collection 20220127
- Changed: Several CF Scoring for better results.
- Fixed: CF `[TrueHD Atmos]` to recognize groups that only use Atmos/TrueHD in their release name.
- Fixed: CF `[TrueHD]` to prevent double scoring with latest update of `[TrueHD Atmos]`.