### PR TITLE
Fix for badly named (dolbyvision) DV files

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -371,7 +371,7 @@ Add this to your `Preferred (3)` with a score of [10]
 Add this to your `Preferred (3)` with a score of [100]
 
 ```bash
-/\b(dv|dovi|dolby[ .]vision)\b/i
+/\b(dv|dovi|dolby[ .]vision|dolbyvision)\b/i
 ```
 
 #### Optional (use these only if you dislike renamed and retagged releases)

--- a/docs/json/radarr/2160p.json
+++ b/docs/json/radarr/2160p.json
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision|DV[ .]HDR10|DV[ .]HLG|DV[ .]SDR)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision|DV[ .]HDR10|DV[ .]HLG|DV[ .]SDR)\\b"
       }
     },
     {

--- a/docs/json/radarr/dv.json
+++ b/docs/json/radarr/dv.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision)\\b"
       }
     },
     {

--- a/docs/json/radarr/hdr-undefined.json
+++ b/docs/json/radarr/hdr-undefined.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision)\\b"
       }
     },
     {

--- a/docs/json/radarr/hdr.json
+++ b/docs/json/radarr/hdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision)\\b"
       }
     },
     {

--- a/docs/json/radarr/hlg.json
+++ b/docs/json/radarr/hlg.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision)\\b"
       }
     },
     {

--- a/docs/json/radarr/pq.json
+++ b/docs/json/radarr/pq.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]vision)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]vision|dolbyvision)\\b"
       }
     },
     {


### PR DESCRIPTION
This allows different DV custom format to deal with badly named DV files