### PR TITLE
Radarr CF LQ FZHD

### DIFF
--- a/docs/json/radarr/lq.json
+++ b/docs/json/radarr/lq.json
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TEKNO3D|TIKO|Liber8)\\b"
+        "value": "\\b(TEKNO3D|TIKO|Liber8|FZHD)\\b"
       }
     }
   ]


### PR DESCRIPTION
Added: `FZHD` to the `Nominated Unwanted Groups` condition.
- Bad Naming
- Wrong and Incorrect Info
- Often Playback issues Audio/Video
- Fake 4K (Re Grade/Upscaled)