### PR TITLE
Update requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,7 @@
 git+https://github.com/fralau/mkdocs_macros_plugin@v0.5.12#egg=mkdocs-macros-plugin
 git+https://github.com/g-provost/lightgallery-markdown@v0.5#egg=lightgallery
-markdown==3.3.6
 mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-git-revision-date-localized-plugin==1.0.1
-mkdocs-material-extensions==1.0.3
 mkdocs-material==8.2.10
 mkdocs-minify-plugin==0.5.0
 mkdocs-redirects==1.0.4
-mkdocs==1.3.0
-pygments==2.12.0
-pymdown-extensions==9.4


### PR DESCRIPTION
According to https://squidfunk.github.io/mkdocs-material/getting-started/#with-pip 

> This will automatically install compatible versions of all dependencies: [MkDocs](https://www.mkdocs.org/), [Markdown](https://python-markdown.github.io/), [Pygments](https://pygments.org/) and [Python Markdown Extensions](https://facelessuser.github.io/pymdown-extensions/). Material for MkDocs always strives to support the latest versions, so there's no need to install those packages separately.

And we can see https://github.com/squidfunk/mkdocs-material/blob/990b24fc8c38168b3b783bcfd8b551deeed6c0cd/requirements.txt#L21-L27 also includes `mkdocs-material-extensions`