### PR TITLE
Fix DoVi without HDR fallback for badly named releases

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -469,7 +469,7 @@ Add this to your `Preferred (3)` with a score of [15]
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]Vision)\b).*/i
+/^(?!.*(HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]?Vision)\b).*/i
 ```
 
 ------


### PR DESCRIPTION
Hi @TRaSH- !
This one fixes badly named DV release withotu HDR fallback, for example this one : `Slow.Horses.S01E06.MULTI.DOLBYVISION.2160p.ATVP.WEB-DL.DDP5.1.Atmos.HEVC-AXLBEN.mp4`

Thanks!