### PR TITLE
Fix regex word boundary

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -497,7 +497,7 @@ Add this to your `Must not contain (2)`
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(-deflate|-inflate))(?=.*([_. ]WEB[_. ]|\\bCAKES\\b|GGEZ|GGWP|GLHF)).*/i
+/^(?!.*(-deflate|-inflate))(?=.*([_. ]WEB[_. ]|\bCAKES\b|GGEZ|GGWP|GLHF)).*/i
 ```
 
 ------


### PR DESCRIPTION
Fixed word boundary by removing escaping introduced in #574 by me.

Sorry about that.