### PR TITLE
Radarr CF [LQ] KIRA

### DIFF
--- a/docs/json/radarr/lq.json
+++ b/docs/json/radarr/lq.json
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TEKNO3D|TIKO|Liber8|FZHD|PATOMiEL)\\b"
+        "value": "\\b(TEKNO3D|TIKO|Liber8|FZHD|PATOMiEL|-KIRA)\\b"
       }
     }
   ]

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,7 @@
+#2022-05-06
+Radarr CF [LQ] KIRA #576
+- Updated: CF [LQ] added `KIRA` to the `Nominated Unwanted Groups` condition. (Wrong main Audio Track in filename)
+
 #2022-05-03
 Sonarr RP RegEx WEBDL 20220503 #573
 - Updated: Fix DoVi without HDR fallback for badly named releases #572


### PR DESCRIPTION
- Updated: CF [LQ] added `KIRA` to the `Nominated Unwanted Groups` condition. (Wrong main Audio Track in filename)