### PR TITLE
Updated: de[42] to be excluded from No -Rlsgroup

### DIFF
--- a/docs/json/radarr/no-rlsgroup.json
+++ b/docs/json/radarr/no-rlsgroup.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "KRaLiMaRKo|E\\.N\\.D|D\\-Z0N3|Koten_Gars|BluDragon"
+        "value": "KRaLiMaRKo|E\\.N\\.D|D\\-Z0N3|de\\[42\\]|Koten_Gars|BluDragon"
       }
     }
   ]


### PR DESCRIPTION
Added the group de[42] to be excluded from the No -RlsGroup CF