### PR TITLE
Sonarr Low Quality Groups - Release Profile

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -268,7 +268,7 @@ Add this to your `Preferred (3)` with a score of [10]
 Add this to your `Preferred (3)` with a score of [-100]
 
 ```bash
-/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3)\b/i
+/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe.ph|Pahe.in)\b/i
 ```
 
 !!! danger "Caution"

--- a/docs/json/sonarr/lqGroups.json
+++ b/docs/json/sonarr/lqGroups.json
@@ -6,7 +6,7 @@
   "preferred": [{
     "score": -100,
     "terms": [
-      "/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3)\\b/i"
+      "/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe.ph|Pahe.in)\\b/i"
     ]
   }],
   "ignored": []

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,13 +1,17 @@
-#2022-05-06
+# 2022-05-09
+Sonarr Low Quality Groups - Release Profile #581
+- Added: Pahe.ph|Pahe.in to the LQ Groups because of their re-encoded microsized releases.
+
+# 2022-05-06
 Radarr CF [LQ] KIRA #576
 - Updated: CF [LQ] added `KIRA` to the `Nominated Unwanted Groups` condition. (Wrong main Audio Track in filename)
 
-#2022-05-03
+# 2022-05-03
 Sonarr RP RegEx WEBDL 20220503 #573
 - Updated: Fix DoVi without HDR fallback for badly named releases #572
 - Updated: Ignore so called scene releases to ignore deflate/inflate
 
-#2022-04-24
+# 2022-04-24
 Starr index page update #560
 - Added: all Star branch versions including warnings
 - Added: How to update to a Starr Apps branche.


### PR DESCRIPTION
- Added: Pahe.ph|Pahe.in to the LQ Groups because of their re-encoded microsized releases.