### PR TITLE
Radarr CF [LQ] PTNK

### DIFF
--- a/docs/json/radarr/lq.json
+++ b/docs/json/radarr/lq.json
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(TEKNO3D|TIKO|Liber8|FZHD|PATOMiEL|-KIRA)\\b"
+        "value": "\\b(TEKNO3D|TIKO|Liber8|FZHD|PATOMiEL|-KIRA|PTNK)\\b"
       }
     }
   ]


### PR DESCRIPTION
- Updated: CF [LQ] added `PTNK` to the `Nominated Unwanted Groups` condition. (Using different sources like EVO releases, BLUR hardcoded subs,  and also strips out all other subs)