### PR TITLE
Sonarr Release Profile Regex WEBDL

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -268,7 +268,7 @@ Add this to your `Preferred (3)` with a score of [10]
 Add this to your `Preferred (3)` with a score of [-100]
 
 ```bash
-/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe\.ph|Pahe\.in)\b/i
+/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe\.ph|Pahe\.in|-NERO)\b/i
 ```
 
 !!! danger "Caution"
@@ -469,7 +469,7 @@ Add this to your `Preferred (3)` with a score of [15]
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]?Vision)\b).*/i
+/^(?!.*(\bSIC\b|HDR|HULU|REMUX))(?=.*\b(DV|Dovi|Dolby[- .]?Vision)\b).*/i
 ```
 
 ------

--- a/docs/json/sonarr/lqGroups.json
+++ b/docs/json/sonarr/lqGroups.json
@@ -6,7 +6,7 @@
   "preferred": [{
     "score": -100,
     "terms": [
-      "/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe\\.ph|Pahe\\.in)\\b/i"
+      "/(TBS|-BRiNK|-CHX|-XLF|-worldmkv|-GHOSTS|-VIDEOHOLE|nhanc3|Pahe\\.ph|Pahe\\.in|-NERO)\\b/i"
     ]
   }],
   "ignored": []

--- a/docs/json/sonarr/optionals.json
+++ b/docs/json/sonarr/optionals.json
@@ -8,7 +8,7 @@
   }, {
     "name": "Ignore Dolby Vision without HDR10 fallback.",
     "trash_id": "436f5a7d08fbf02ba25cb5e5dfe98e55",
-    "term": "/^(?!.*(HDR|HULU|REMUX))(?=.*\\b(DV|Dovi|Dolby[- .]?Vision)\\b).*/i"
+    "term": "/^(?!.*(\\bSIC\\b|HDR|HULU|REMUX))(?=.*\\b(DV|Dovi|Dolby[- .]?Vision)\\b).*/i"
   }, {
     "name": "Ignore The Group -SCENE",
     "trash_id": "f3f0f3691c6a1988d4a02963e69d11f2",


### PR DESCRIPTION
- Added: The group `SIC` to `Optional - Ignore Dolby Vision without HDR10 fallback` exception.
- Added: The group `NERO` to `Low Quality Groups - Release Profile` because they only provide dubbed French audio track.