### PR TITLE
fix: software versions

### DIFF
--- a/docs/Downloaders/index.md
+++ b/docs/Downloaders/index.md
@@ -20,8 +20,8 @@ Here you will find Guides for several Download Clients.
 
 [Deluge](/Downloaders/Deluge/)
 
-![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fdeluge%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5)
+![version](https://img.shields.io/github/release/linuxserver/docker-deluge.svg?color=4051B5&style=for-the-badge&logo=github)
 
 [ruTorrent](/Downloaders/ruTorrent/)
 
-![version](https://img.shields.io/badge/dynamic/json?query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2Fhotio%2Fruotrrent%2Frelease%2FVERSION.json&label=Latest%20Version&style=for-the-badge&color=4051B5)
+![version](https://img.shields.io/github/v/release/Novik/ruTorrent.svg?color=4051B5&style=for-the-badge&logo=github)


### PR DESCRIPTION
Change to more reliable release versioning for versions of deluge and rutorrent.

it should be noted that rutorrent is just a front end and the rtorrent version should be used instead.