### PR TITLE
Sonarr cf separated group conditions

### DIFF
--- a/docs/json/sonarr/v4/normal/dislike-obfuscated.json
+++ b/docs/json/sonarr/v4/normal/dislike-obfuscated.json
@@ -3,12 +3,147 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "Dislike Obfuscated",
+      "name": "4P",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(-4P|-4Planet|-AsRequested|-BUYMORE|-Chamele0n|-GEROV|-iNC0GNiTO|-NZBGeek|-Obfuscated|-postbot|-Rakuv|-Scrambled|-WhiteRev|-xpost|-WRTEAM|-CAPTCHA)\\b"
+        "value": "-4P\\b"
+      }
+    },
+    {
+      "name": "4Planet",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-4Planet\\b"
+      }
+    },
+    {
+      "name": "AsRequested",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-AsRequested\\b"
+      }
+    },
+    {
+      "name": "BUYMORE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-BUYMORE\\b"
+      }
+    },
+    {
+      "name": "Chamele0n",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-Chamele0n\\b"
+      }
+    },
+    {
+      "name": "GEROV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-GEROV\\b"
+      }
+    },
+    {
+      "name": "iNC0GNiTO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-iNC0GNiTO\\b"
+      }
+    },
+    {
+      "name": "NZBGeek",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-NZBGeek\\b"
+      }
+    },
+    {
+      "name": "Obfuscated",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-Obfuscated\\b"
+      }
+    },
+    {
+      "name": "postbot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-postbot\\b"
+      }
+    },
+    {
+      "name": "Rakuv",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-Rakuv\\b"
+      }
+    },
+    {
+      "name": "Scrambled",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Scrambled\\b"
+      }
+    },
+    {
+      "name": "WhiteRev",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-WhiteRev\\b"
+      }
+    },
+    {
+      "name": "xpost",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-xpost\\b"
+      }
+    },
+    {
+      "name": "WRTEAM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-WRTEAM\\b"
+      }
+    },
+    {
+      "name": "CAPTCHA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-CAPTCHA\\b"
       }
     }
   ]

--- a/docs/json/sonarr/v4/normal/dislike-retags.json
+++ b/docs/json/sonarr/v4/normal/dislike-retags.json
@@ -3,12 +3,39 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "Dislike retags",
+      "name": "[rartv]",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "(\\[rartv\\]|\\[rarbg\\]|\\[eztv\\]|\\[TGx\\])"
+        "value": "\\[rartv\\]"
+      }
+    },
+    {
+      "name": "[rarbg]",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[rarbg\\]"
+      }
+    },
+    {
+      "name": "[eztv]",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[eztv\\]"
+      }
+    },
+    {
+      "name": "[TGx]",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[TGx\\]"
       }
     }
   ]

--- a/docs/json/sonarr/v4/normal/dislike-scene-releases.json
+++ b/docs/json/sonarr/v4/normal/dislike-scene-releases.json
@@ -1,0 +1,51 @@
+{
+  "name": "Dislike scene releases",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Dislike scene releases",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ])).*"
+      }
+    },
+    {
+      "name": "CAKES",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-CAKES\\b"
+      }
+    },
+    {
+      "name": "GGEZ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-GGEZ\\b"
+      }
+    },
+    {
+      "name": "GGWP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-GGWP\\b"
+      }
+    },
+    {
+      "name": "GLHF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-GLHF\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/v4/normal/hdr-undefined.json
+++ b/docs/json/sonarr/v4/normal/hdr-undefined.json
@@ -1,0 +1,78 @@
+{
+  "name": "HDR (undefined)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Groups (Missing HDR)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(FraMeSToR|HQMUX)\\b"
+      }
+    },
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "Not DV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+      }
+    },
+    {
+      "name": "Not HDR10+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10Plus|HDR10(\\b\\+)"
+      }
+    },
+    {
+      "name": "Not HDR10",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bHDR10(\\b[^+|Plus])"
+      }
+    },
+    {
+      "name": "Not PQ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(PQ)\\b"
+      }
+    },
+    {
+      "name": "Not HLG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(HLG)\\b"
+      }
+    },
+    {
+      "name": "Not SDR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\bSDR(\\b|\\d)"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Updated: Sonarr-CF [Dislike Obfuscated] Switched to separate conditions for the groups
- Changed: CF [Dislike Obfuscated] Conditions to separate conditions for the groups.

Updated: Sonarr-CF [Dislike retags] Switched to separate conditions for the groups
- Changed: CF [Dislike retags] Conditions to separate conditions for the groups.

Updated: Sonarr-CF [Dislike scene releases] Switched to separate conditions for the groups
- Changed: CF [Dislike scene releases] Conditions to separate conditions for the groups.

Updated: Sonarr-CF [HDR (undefined)]
- NEW: Added [HDR (undefined)] [Score: 500]