### PR TITLE
Radarr french cf

### DIFF
--- a/docs/json/radarr/user-radarr-cf/.editorconfig
+++ b/docs/json/radarr/user-radarr-cf/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = false
+
+[*.json]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+#insert_final_newline = true

--- a/docs/json/radarr/user-radarr-cf/fansub.json
+++ b/docs/json/radarr/user-radarr-cf/fansub.json
@@ -1,0 +1,24 @@
+{
+  "name": "FANSUB",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "FASTSUB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bFAST[ ._-]?SUB\\b"
+      }
+    },
+    {
+      "name": "FANSUB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bFAN[ ._-]?SUB\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/french-hq-best.json
+++ b/docs/json/radarr/user-radarr-cf/french-hq-best.json
@@ -1,0 +1,114 @@
+{
+  "name": "French - HQ [Best]",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "BEO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)BEO\\b"
+      }
+    },
+    {
+      "name": "FCK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)FCK\\b"
+      }
+    },
+    {
+      "name": "FoX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)FoX\\b"
+      }
+    },
+    {
+      "name": "HLX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)HLX\\b"
+      }
+    },
+    {
+      "name": "JKF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)JKF\\b"
+      }
+    },
+    {
+      "name": "KALiPSO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)KALiPSO\\b"
+      }
+    },
+    {
+      "name": "MARBLECAKE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)MARBLECAKE\\b"
+      }
+    },
+    {
+      "name": "MeMyl",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)MeMyI\\b"
+      }
+    },
+    {
+      "name": "MTDK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)MTDK\\b"
+      }
+    },
+    {
+      "name": "NEO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)NEO\\b"
+      }
+    },
+    {
+      "name": "RELiCS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)RELiCS\\b"
+      }
+    },
+    {
+      "name": "Scaph",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)Scaph\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/french-hq-correct.json
+++ b/docs/json/radarr/user-radarr-cf/french-hq-correct.json
@@ -1,0 +1,150 @@
+{
+  "name": "French - HQ [Correct]",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "ALL4YOU",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)ALL4YOU\\b"
+      }
+    },
+    {
+      "name": "AMNESIA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)AMNESIA\\b"
+      }
+    },
+    {
+      "name": "ARK01",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)ARK01\\b"
+      }
+    },
+    {
+      "name": "BARBiE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)BARBiE\\b"
+      }
+    },
+    {
+      "name": "DIEBEX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)DIEBEX\\b"
+      }
+    },
+    {
+      "name": "FTMVHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)FTMVHD\\b"
+      }
+    },
+    {
+      "name": "HeavyWeight",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)HeavyWeight\\b"
+      }
+    },
+    {
+      "name": "JAX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)JAX\\b"
+      }
+    },
+    {
+      "name": "MoJiTo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)MoJiTo\\b"
+      }
+    },
+    {
+      "name": "NPMS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)NPMS\\b"
+      }
+    },
+    {
+      "name": "ONLYMOViE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)ONLYMOViE\\b"
+      }
+    },
+    {
+      "name": "playWEB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)playWEB\\b"
+      }
+    },
+    {
+      "name": "SLAY3R",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)SLAY3R\\b"
+      }
+    },
+    {
+      "name": "TkHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)TkHD\\b"
+      }
+    },
+    {
+      "name": "USR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)USR\\b"
+      }
+    },
+    {
+      "name": "UTT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)UTT\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/french-hq-great.json
+++ b/docs/json/radarr/user-radarr-cf/french-hq-great.json
@@ -1,0 +1,69 @@
+{
+  "name": "French - HQ [Great]",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "ALLDAYiN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)ALLDAYiN\\b"
+      }
+    },
+    {
+      "name": "EXTREME",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)EXTREME\\b"
+      }
+    },
+    {
+      "name": "FRATERNiTY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)FRATERNiTY\\b"
+      }
+    },
+    {
+      "name": "KLI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)KLI\\b"
+      }
+    },
+    {
+      "name": "NoTag",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)NoTag\\b"
+      }
+    },
+    {
+      "name": "PopHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)PopHD\\b"
+      }
+    },
+    {
+      "name": "ZeL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)ZeL\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/french-scene.json
+++ b/docs/json/radarr/user-radarr-cf/french-scene.json
@@ -1,0 +1,204 @@
+{
+  "name": "French Scene",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(AiRDOCS|AiRLiNE|AiRTV|AKLHD|AZR)\\b"
+      }
+    },
+    {
+      "name": "B",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(BiPOLAR|BRiNK)\\b"
+      }
+    },
+    {
+      "name": "C",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(CARAPiLS|CiELOS|CiNEFiLE|CONVOY|CRYPT0)\\b"
+      }
+    },
+    {
+      "name": "D",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(D4KiD|DEAL|DUSS)\\b"
+      }
+    },
+    {
+      "name": "E",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(EUBDS)\\b"
+      }
+    },
+    {
+      "name": "F",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(FHD|FiDELiO|FiDO|ForceBleue|F(or)?W(ard)?|FRENCHDEADPOOL2)\\b"
+      }
+    },
+    {
+      "name": "G",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(GECKOS|GHOULS|Goatlove)\\b"
+      }
+    },
+    {
+      "name": "H",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(HAWAII|HOLiDAYS|HYBRiS)\\b"
+      }
+    },
+    {
+      "name": "I",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(iDHD|iRLS)\\b"
+      }
+    },
+    {
+      "name": "J",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(JMT|JUSTICELEAGUE)\\b"
+      }
+    },
+    {
+      "name": "K",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(KAZETV|KOGi)\\b"
+      }
+    },
+    {
+      "name": "L",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(LaoZi|LOST|LOUVRE)\\b"
+      }
+    },
+    {
+      "name": "M",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(MAGiCAL|MELBA|METALLIKA|MUNSTER|MUxHD)\\b"
+      }
+    },
+    {
+      "name": "N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(NERDHD|NERO|NOWiNHD|NrZ|NTK)\\b"
+      }
+    },
+    {
+      "name": "O",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(OohLaLa)\\b"
+      }
+    },
+    {
+      "name": "P",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(PANZeR|PFa|PiNKPANTERS|PKPTRS|PRiDEHD|PRODiGE|PRXHD|PURE|PUREWASTEOFBW)\\b"
+      }
+    },
+    {
+      "name": "R",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(Ryotox)\\b"
+      }
+    },
+    {
+      "name": "S",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(SCENE|SEiGHT|SESKAPiLE|SH0W|SHiNiGAMiUHD|SiGeRiS|SODAPOP|SOZER|SPINE|SPOiLER|STRINGERBELL)\\b"
+      }
+    },
+    {
+      "name": "T",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(THENiGHTMAREiNHD|THiNK|THREESOME|Thursday13th|TiMELiNE|TSuNaMi)\\b"
+      }
+    },
+    {
+      "name": "U",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(UKDHD|UKDTV|ULSHD|Ulysse)\\b"
+      }
+    },
+    {
+      "name": "V",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(VENUE|VoMiT)\\b"
+      }
+    },
+    {
+      "name": "Z",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b([ ._-]|\\[)(ZEST)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/multi-vff.json
+++ b/docs/json/radarr/user-radarr-cf/multi-vff.json
@@ -1,0 +1,24 @@
+{
+  "name": "MULTI VFF ",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Multi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\bMulti(\\b|\\d)"
+      }
+    },
+    {
+      "name": "VFF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((TRUE)?FR(ENCH)?|VO?F(F|I|[0-9])?)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/vfq.json
+++ b/docs/json/radarr/user-radarr-cf/vfq.json
@@ -1,0 +1,15 @@
+{
+  "name": "VFQ",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "VFQ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "VFQ"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/vostfr.json
+++ b/docs/json/radarr/user-radarr-cf/vostfr.json
@@ -1,0 +1,24 @@
+{
+  "name": "VOSTFR",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "VOSTFR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bVOSTFR?(F|I|Q|R|[0-9])?\\b"
+      }
+    },
+    {
+      "name": "SUBFRENCH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSUBFR(ENCH)?\\b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
VF: version française (French version)
VOF: version originale française (French original version) 
VFF: version française de France (France French version)
VFQ: version française québécoise (French Canadian version)
VFI: version française internationale (French international version)
VF2: version française double (double French version, should possess both the French and French Canadian audio), which I dunno why sometimes become VF1 or VF3 (I suspect VF1 is only one of the two but unknown and VF3 was with the African French version, only saw this one time) 
TRUEFRENCH: same as VFF
VOSTFR: version originale sous-titré français (original version with French sub)
FANSUB/FASTSUB: sub made by fan (that is how French indexers are reporting it most of the time)

Provided by: [@nicetsy](https://github.com/NiceTSY/)