### PR TITLE
Radarr cf dv hdr10 fix for bad (re)named files

### DIFF
--- a/docs/json/radarr/dv-hdr10.json
+++ b/docs/json/radarr/dv-hdr10.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/radarr/dv-hlg.json
+++ b/docs/json/radarr/dv-hlg.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/radarr/dv-sdr.json
+++ b/docs/json/radarr/dv-sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/radarr/dv-webdl.json
+++ b/docs/json/radarr/dv-webdl.json
@@ -46,7 +46,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     }
   ]

--- a/docs/json/radarr/dv.json
+++ b/docs/json/radarr/dv.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/radarr/hdr10.json
+++ b/docs/json/radarr/hdr10.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {
@@ -56,6 +56,15 @@
       "required": true,
       "fields": {
         "value": "\\bSDR(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not DV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
       }
     }
   ]

--- a/docs/json/radarr/hdr10plus.json
+++ b/docs/json/radarr/hdr10plus.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {


### PR DESCRIPTION
- Added: Fix for bad (re)named DV HDR10 releases.
- Added: `Not DV` Condition to `[HDR10]` prevent double scoring for bad (re)named DV HDR10 Releases.