### PR TITLE
add "KOGI" to ignore scene releases JSON

### DIFF
--- a/docs/json/sonarr/optionals.json
+++ b/docs/json/sonarr/optionals.json
@@ -16,7 +16,7 @@
   }, {
     "name": "Ignore so called scene releases",
     "trash_id": "5bc23c3a055a1a5d8bbe4fb49d80e0cb",
-    "term": "/^(?!.*(-deflate|-inflate))(?=.*([_. ]WEB[_. ]|\\bCAKES\\b|GGEZ|GGWP|GLHF)).*/i"
+    "term": "/^(?!.*(-deflate|-inflate))(?=.*([_. ]WEB[_. ]|\\bCAKES\\b|GGEZ|GGWP|GLHF|KOGI)).*/i"
   }],
   "required": [],
   "preferred": [{


### PR DESCRIPTION
Add's "KOGI" to ignore scene releases to cover Blu renaming the releases.