### PR TITLE
Sonarr cf dv hdr10 fix for bad (re)named files

### DIFF
--- a/docs/json/sonarr/v4/normal/dislike-scene-releases.json
+++ b/docs/json/sonarr/v4/normal/dislike-scene-releases.json
@@ -46,6 +46,24 @@
       "fields": {
         "value": "-GLHF\\b"
       }
+    },
+    {
+      "name": "KOGI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-KOGI\\b"
+      }
+    },
+    {
+      "name": "GOSSIP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "-GOSSIP\\b"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/v4/normal/dv-hdr10.json
+++ b/docs/json/sonarr/v4/normal/dv-hdr10.json
@@ -8,7 +8,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/v4/normal/dv-hlg.json
+++ b/docs/json/sonarr/v4/normal/dv-hlg.json
@@ -17,7 +17,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/v4/normal/dv-sdr.json
+++ b/docs/json/sonarr/v4/normal/dv-sdr.json
@@ -17,7 +17,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/v4/normal/dv-webdl.json
+++ b/docs/json/sonarr/v4/normal/dv-webdl.json
@@ -39,12 +39,12 @@
       }
     },
     {
-      "name": "DV HDR10",
+      "name": "Not DV HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/v4/normal/dv.json
+++ b/docs/json/sonarr/v4/normal/dv.json
@@ -17,7 +17,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {

--- a/docs/json/sonarr/v4/normal/hdr10.json
+++ b/docs/json/sonarr/v4/normal/hdr10.json
@@ -17,7 +17,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {
@@ -54,6 +54,15 @@
       "required": true,
       "fields": {
         "value": "\\bSDR(\\b|\\d)"
+      }
+    },
+    {
+      "name": "Not DV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/v4/normal/hdr10plus.json
+++ b/docs/json/sonarr/v4/normal/hdr10plus.json
@@ -17,7 +17,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10)\\b"
+        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
       }
     },
     {


### PR DESCRIPTION
- Added: Fix for bad (re)named DV HDR10 releases.
- Added: `Not DV` Condition to `[HDR10]` prevent double scoring for bad (re)named DV HDR10 Releases.
- Added: Scene KOGI + GOSSIP