### PR TITLE
Radarr cf 20220621

### DIFF
--- a/docs/json/radarr/3d.json
+++ b/docs/json/radarr/3d.json
@@ -3,13 +3,24 @@
   "trash_score": "-10000",
   "name": "3D",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
+  "specifications": [
+    {
       "name": "3D",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
-          "value": "\\b3d|sbs|half[ .-]ou|half[ .-]sbs\\b"
+        "value": "\\b3d|sbs|half[ .-]ou|half[ .-]sbs\\b"
       }
-  }]
+    },
+    {
+      "name": "BluRay3D",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BluRay3D)\\b"
+      }
+    }
+  ]
 }

--- a/docs/json/radarr/dv-webdl.json
+++ b/docs/json/radarr/dv-webdl.json
@@ -41,12 +41,12 @@
       }
     },
     {
-      "name": "DV HDR10",
+      "name": "Not HDR",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HDR10|HDR10[ .]DV)\\b"
+        "value": "\\bHDR(\\b|\\d)"
       }
     }
   ]


### PR DESCRIPTION
- Updated: CF `[3D]` added 3D group `BluRay3D`.
- Updated: CF `[DV (WEBDL)]` replaced condition `DV HDR10` with `No HDR`.