### PR TITLE
More release version CFs

### DIFF
--- a/docs/json/radarr/user-radarr-cf/movie-version/4klight.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/4klight.json
@@ -1,0 +1,26 @@
+{
+  "trash_id": "47e3eeee29a787cc09ce0eeedd1d7cb9",
+  "trash_score": "0",
+  "name": "4KLight",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "4K Light",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b4K[ .-]?Light\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/movie-version/fansub.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/fansub.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "18098a3ae4e97caa9fa3882db323099f",
+  "trash_score": "0",
+  "name": "FanSub",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "FanSub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bFan[ .-]?Sub(bed)?\\b"
+      }
+    },
+    {
+      "name": "FastSub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bFast[ .-]?Sub(bed)?\\b"
+      }
+    },
+    {
+      "name": "SoftSub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSoft[ .-]?Sub(bed)?\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/movie-version/hdlight.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/hdlight.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "c40f3d912c26400237b8ffb590a4a087",
+  "trash_score": "0",
+  "name": "HDLight",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "1080p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 1080
+      }
+    },
+    {
+      "name": "HD Light",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bHD[ .-]?Light\\b"
+      }
+    },
+    {
+      "name": "mini HD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bm(ini)?[ .-]?HD\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/movie-version/limited.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/limited.json
@@ -1,0 +1,53 @@
+{
+  "trash_id": "46691dca41611b560a786a1d8b354495",
+  "trash_score": "0",
+  "name": "LiMiTED",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "LiMiTED",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(?<!-)LiMiTED\\b"
+      }
+    },
+    {
+      "name": "FESTiVAL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(?<!-)FESTiVAL\\b"
+      }
+    },
+    {
+      "name": "Straight to Video",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(?<!-)STV\\b"
+      }
+    },
+    {
+      "name": "Direct to Video",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(?<!-)DTV\\b"
+      }
+    },
+    {
+      "name": "Directement en vidéo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(?<!-)DEV\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/movie-version/restored.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/restored.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "ae43ba69db61432e187d8f57a740d3fe",
+  "trash_score": "0",
+  "name": "Restored",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "RESTORED",
+      "implementation": "EditionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\bRESTORED\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/user-radarr-cf/movie-version/subforced.json
+++ b/docs/json/radarr/user-radarr-cf/movie-version/subforced.json
@@ -1,0 +1,26 @@
+{
+  "trash_id": "bd1212a0f575bf5833c4591f88a53801",
+  "trash_score": "0",
+  "name": "SubForced",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "SUBFORCED",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSUBFORCED\\b"
+      }
+    },
+    {
+      "name": "HARDSUB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bHARDSUB\\b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Custom release version

Those release version CFs were not included in the base guide. I have found them quite useful.

## SubForced

Indicate subtitles embedded in the video that appear during foreign language passages. HARDSUB is an equivalent.

## FanSub

FanSub, similar to the FastSub tag, indicates that the subtitle is a quick release before the release of an official subtitle.

## Limited

This tag means that the film has had only a limited distribution in cinemas (sometimes less than 250 cinemas). 
Generally, these are art house films, or medium-length films. Similar tags are:
  - Festival: a movie which hasn't been shown in a public theatre, but have been shown on a film festival (such as Cannes Film Festival)
  - STV: Straight to Video, refers to a film that has never been released in theatre
  - DTV: Direct to Video, refers to a film that has never been released in theatre
  - DEV: Directement en vidéo (French for DTV)

## Restored

This tag means that it is an old movie that have been restored to today “standard”.

## HDLight

HDLight, for High Definition Light, refer to a High Definition with a light release weight.
Encoding said to be in HDLight or mHD (medium High Definition), claim to be the best possible resolution while being in a reasonable file size.

## 4KLight

Same as for HDLight but for 4K movies.

## Other notes

md5 ID and score already included.