### PR TITLE
Raised score from `25` to `800` to match `Imax Enhanced`.

### DIFF
--- a/docs/json/radarr/imax.json
+++ b/docs/json/radarr/imax.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "eecf3a857724171f968a66cb5719e152",
-  "trash_score": "25",
+  "trash_score": "800",
   "name": "IMAX",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [


### PR DESCRIPTION
- Updated: CF `[IMAX]` Raised score from `25` to `800` to match `Imax Enhanced`.