### PR TITLE
Removed: EVO from the [LQ]

### DIFF
--- a/docs/json/radarr/lq.json
+++ b/docs/json/radarr/lq.json
@@ -525,15 +525,6 @@
       "fields": {
         "value": "NoGr(ou)?p"
       }
-    },
-    {
-      "name": "EVO",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "[-. ]EVO(TGX)?\\b"
-      }
     }
   ]
 }


### PR DESCRIPTION
- Removed: EVO from the `[LQ]`, please use `[EVO (NOWEBL)]`