### PR TITLE
FonduemangVI\Update hq-web-tier-1

### DIFF
--- a/docs/json/sonarr/v4/normal/hq-web-tier-1.json
+++ b/docs/json/sonarr/v4/normal/hq-web-tier-1.json
@@ -156,13 +156,22 @@
       }
     },
     {
-      "name": "SIC",
+      "name": "SiC",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "-SiC\\b"
       }
+    },
+    {
+        "name": "ABBiE",
+        "implementation": "ReleaseTitleSpecification",
+        "negate": false,
+        "required": false,
+        "fields": {
+          "value": "-ABBiE\\b"
+        }
     }
   ]
 }


### PR DESCRIPTION
Added ABBiE to Tier 1. @TRaSH- not sure if we should have them in Tier 1 or 2, given SiC and ABBiE are Tier 2 for Sonarr V3. However SiC is Tier 1 for qsonarr