### PR TITLE
Fix: CF [MA] false positive

### DIFF
--- a/docs/json/radarr/ma.json
+++ b/docs/json/radarr/ma.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(ma)\\b(?=.*\\bweb[ ._-]?(dl|rip)\\b)"
+        "value": "(?<!dts[ .-]?hd[ .-]?)ma\\b(?=.*\\bweb[ ._-]?(dl|rip)\\b)"
       }
     }
   ]


### PR DESCRIPTION
- Fix: CF `[MA]` false positive, seems in some cases Radarr picks up the path for the CF, and it triggered false on `DTS-HD MA`.