### PR TITLE
Add warning to qBittorrent about ZFS/Pre-Allocate

### DIFF
--- a/docs/Downloaders/qBittorrent/Basic-Setup.md
+++ b/docs/Downloaders/qBittorrent/Basic-Setup.md
@@ -29,10 +29,12 @@
 
 1. Pre-allocated disk space for the added torrents, this limits fragmentation and also makes sure if you use a cache drive or a feeder disk that the space is available.
 
-!! warning Do not set Pre-allocated disk space if you are using ZFS as your filesystem as ZFS [does not support fallocate](https://github.com/openzfs/zfs/issues/326)
-
     !!! check ""
         **Suggested: `Enabled`**
+
+    !!! warning
+
+        Do not set Pre-allocated disk space if you are using ZFS as your filesystem as ZFS [does not support fallocate](https://github.com/openzfs/zfs/issues/326){:target="_blank" rel="noopener noreferrer"}
 
 ### Saving Management
 

--- a/docs/Downloaders/qBittorrent/Basic-Setup.md
+++ b/docs/Downloaders/qBittorrent/Basic-Setup.md
@@ -29,6 +29,8 @@
 
 1. Pre-allocated disk space for the added torrents, this limits fragmentation and also makes sure if you use a cache drive or a feeder disk that the space is available.
 
+!! warning Do not set Pre-allocated disk space if you are using ZFS as your filesystem as ZFS [does not support fallocate](https://github.com/openzfs/zfs/issues/326)
+
     !!! check ""
         **Suggested: `Enabled`**
 


### PR DESCRIPTION
ZFS does not support fallocate[1] which means if the `pre-allocate`
option is set to true qBittorrent will error when adding torrent files

1. https://github.com/openzfs/zfs/issues/326