### PR TITLE
Dislike bad dual audio groups

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -47,17 +47,18 @@ I also made 3 guides related to this one.
 
 ------
 
-| Movie Versions                                | Unwanted                           | Misc                                  | HQ Source Groups      | Streaming Services           |
-| --------------------------------------------- | ---------------------------------- | ------------------------------------- | --------------------- | ---------------------------- |
-| [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                | [Repack/Proper](#repack-proper)       | [HQ-Remux](#hq-remux) | [Amazon](#amzn)              |
-| [Remaster](#remaster)                         | [EVO (no WEBDL)](#evo-no-webdl)    | [Repack2](#repack2)                   | [HQ](#hq)             | [Apple TV+](#aptv)           |
-| [4K Remaster](#4k-remaster)                   | [LQ](#lq)                          | [Multi](#multi)                       | [HQ-WEBDL](#hq-webdl) | [Disney+](#dsnp)             |
-| [Special Editions](#special-edition)          | [x265 (720/1080p)](#x265-7201080p) | [x264](#x264)                         |                       | [HBO Max](#hmax)             |
-| [Criterion Collection](#criterion-collection) | [3D](#3d)                          | [x265](#x265)                         |                       | [Hulu](#hulu)                |
-| [Theatrical Cut](#theatrical-cut)             | [No-RlsGroup](#no-rlsgroup)        | [MPEG2](#mpeg2)                       |                       | [Netflix](#nf)               |
-| [IMAX](#imax)                                 | [Obfuscated](#obfuscated)          | [FreeLeech](#freeleech)               |                       | [Peacock TV](#pcok)          |
-| [IMAX Enhanced](#imax-enhanced)               | [Retags](#retags)                  | [Dutch Groups](#dutch-groups)         |                       | [Paramount+](#pmtp)          |
-|                                               | [DV (WEBDL)](#dv-webdl)            | [Anime Dual Audio](#anime-dual-audio) |                       | [Movies Anywhere](#ma)       |
+| Movie Versions                                | Unwanted                             | Misc                                  | HQ Source Groups      | Streaming Services           |
+| --------------------------------------------- | ------------------------------------ | ------------------------------------- | --------------------- | ---------------------------- |
+| [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)                  | [Repack/Proper](#repack-proper)       | [HQ-Remux](#hq-remux) | [Amazon](#amzn)              |
+| [Remaster](#remaster)                         | [EVO (no WEBDL)](#evo-no-webdl)      | [Repack2](#repack2)                   | [HQ](#hq)             | [Apple TV+](#aptv)           |
+| [4K Remaster](#4k-remaster)                   | [LQ](#lq)                            | [Multi](#multi)                       | [HQ-WEBDL](#hq-webdl) | [Disney+](#dsnp)             |
+| [Special Editions](#special-edition)          | [x265 (720/1080p)](#x265-7201080p)   | [x264](#x264)                         |                       | [HBO Max](#hmax)             |
+| [Criterion Collection](#criterion-collection) | [3D](#3d)                            | [x265](#x265)                         |                       | [Hulu](#hulu)                |
+| [Theatrical Cut](#theatrical-cut)             | [No-RlsGroup](#no-rlsgroup)          | [MPEG2](#mpeg2)                       |                       | [Netflix](#nf)               |
+| [IMAX](#imax)                                 | [Obfuscated](#obfuscated)            | [FreeLeech](#freeleech)               |                       | [Peacock TV](#pcok)          |
+| [IMAX Enhanced](#imax-enhanced)               | [Retags](#retags)                    | [Dutch Groups](#dutch-groups)         |                       | [Paramount+](#pmtp)          |
+|                                               | [DV (WEBDL)](#dv-webdl)              | [Anime Dual Audio](#anime-dual-audio) |                       | [Movies Anywhere](#ma)       |
+|                                               | [Bad Dual Groups](#bad-dual-groups)  |                                       |                       |                              |
 
 ------
 
@@ -997,6 +998,22 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/dv-webdl.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### Bad Dual Groups
+
+??? faq "Bad dual groups - [CLICK TO EXPAND]"
+    These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
+    Also they often even rename the release name in to Portuguese.
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/bad-dual-groups.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -505,7 +505,7 @@ Add this to your `Must not contain (2)`
 
 ??? question "WHY ? - [CLICK TO EXPAND]"
 
-    These groups add their own preferred language (ex. Portugese) as the main audio track.
+    These groups add their own preferred language (ex. Portuguese) as the main audio track.
 
 Add this to your `Must not contain (2)`
 

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -501,6 +501,18 @@ Add this to your `Must not contain (2)`
 
 ```
 
+#### Optional - Ignore Annoying Dual Audio Groups
+
+??? question "WHY ? - [CLICK TO EXPAND]"
+
+    These groups add their own preferred language (ex. Portugese) as the main audio track.
+
+Add this to your `Must not contain (2)`
+
+```bash
+/\b(-alfaHD|-BAT|-BNd|-C.A.A|-Cory|-FF|-FOXX|-G4RiS|-GUEIRA|-N3G4N|-PD|-RiPER|-RK|-SiGLA|-Tars|-WTV|-Yatogam1|-YusukeFLA)\b/i
+```
+
 ------
 
 ### A little explanation of the scores and why

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -505,7 +505,8 @@ Add this to your `Must not contain (2)`
 
 ??? question "WHY ? - [CLICK TO EXPAND]"
 
-    These groups add their own preferred language (ex. Portuguese) as the main audio track.
+    These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
+    Also they often even rename the release name in to Portuguese.
 
 Add this to your `Must not contain (2)`
 

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -501,7 +501,7 @@ Add this to your `Must not contain (2)`
 
 ```
 
-#### Optional - Ignore Annoying Dual Audio Groups
+#### Optional - Ignore Bad Dual Audio Groups
 
 ??? question "WHY ? - [CLICK TO EXPAND]"
 

--- a/docs/json/radarr/bad-dual-groups.json
+++ b/docs/json/radarr/bad-dual-groups.json
@@ -1,0 +1,170 @@
+{
+  "trash_id": "b6832f586342ef70d9c128d40c07b872",
+  "trash_score": "-10000",
+  "name": "Bad Dual Groups",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "alfaHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-alfaHD)\\b"
+      }
+    },
+    {
+      "name": "BAT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-BAT)\\b"
+      }
+    },
+    {
+      "name": "BNd",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-BNd)\\b"
+      }
+    },
+    {
+      "name": "C.A.A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-C.A.A)\\b"
+      }
+    },
+    {
+      "name": "Cory",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-Cory)\\b"
+      }
+    },
+    {
+      "name": "FF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-FF)\\b"
+      }
+    },
+    {
+      "name": "FOXX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-FOXX)\\b"
+      }
+    },
+    {
+      "name": "G4RiS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-G4RiS)\\b"
+      }
+    },
+    {
+      "name": "GUEIRA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-GUEIRA)\\b"
+      }
+    },
+    {
+      "name": "N3G4N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-N3G4N)\\b"
+      }
+    },
+    {
+      "name": "PD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-PD)\\b"
+      }
+    },
+    {
+      "name": "RiPER",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-RiPER)\\b"
+      }
+    },
+    {
+      "name": "RK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-RK)\\b"
+      }
+    },
+    {
+      "name": "SiGLA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-SiGLA)\\b"
+      }
+    },
+    {
+      "name": "Tars",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-Tars)\\b"
+      }
+    },
+    {
+      "name": "WTV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-WTV)\\b"
+      }
+    },
+    {
+      "name": "Yatogam1",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-Yatogam1)\\b"
+      }
+    },
+    {
+      "name": "YusukeFLA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-YusukeFLA)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/optionals.json
+++ b/docs/json/sonarr/optionals.json
@@ -60,7 +60,7 @@
       "term": "/(1-.+)$/i"
       }, {
         "name": "Dislike Annoying Dual Audio Groups",
-        "trash_id": "dac17aca202e4b5d28bef5070c5c5cfb",
+        "trash_id": "538bad00ee6f8aced8e0db5218b8484c",
         "term": "/\\b(-alfaHD|-BAT|-BNd|-C.A.A|-Cory|-FF|-FOXX|-G4RiS|-GUEIRA|-N3G4N|-PD|-RiPER|-RK|-SiGLA|-Tars|-WTV|-Yatogam1|-YusukeFLA)\\b/i"
       }, {
     }]

--- a/docs/json/sonarr/optionals.json
+++ b/docs/json/sonarr/optionals.json
@@ -58,6 +58,12 @@
       "name": "Dislike release containing: 1-",
       "trash_id": "236a3626a07cacf5692c73cc947bc280",
       "term": "/(1-.+)$/i"
+      }, {
+        "name": "Dislike Annoying Dual Audio Groups",
+        "trash_id": "dac17aca202e4b5d28bef5070c5c5cfb",
+        "term": "/\\b(-alfaHD|-BAT|-BNd|-C.A.A|-Cory|-FF|-FOXX|-G4RiS|-GUEIRA|-N3G4N|-PD|-RiPER|-RK|-SiGLA|-Tars|-WTV|-Yatogam1|-YusukeFLA)\\b/i"
+      }, {
     }]
   }]
 }
+

--- a/docs/json/sonarr/optionals.json
+++ b/docs/json/sonarr/optionals.json
@@ -59,7 +59,7 @@
       "trash_id": "236a3626a07cacf5692c73cc947bc280",
       "term": "/(1-.+)$/i"
       }, {
-        "name": "Dislike Annoying Dual Audio Groups",
+        "name": "Dislike Bad Dual Audio Groups",
         "trash_id": "538bad00ee6f8aced8e0db5218b8484c",
         "term": "/\\b(-alfaHD|-BAT|-BNd|-C.A.A|-Cory|-FF|-FOXX|-G4RiS|-GUEIRA|-N3G4N|-PD|-RiPER|-RK|-SiGLA|-Tars|-WTV|-Yatogam1|-YusukeFLA)\\b/i"
       }, {

--- a/includes/cf/unwanted.md
+++ b/includes/cf/unwanted.md
@@ -9,6 +9,7 @@
     | No-RlsGroup      | -10000 | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup){: .header-icons target=_blank rel="noopener noreferrer" } |
     | Obfuscated       | -10000 | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#obfuscated){: .header-icons target=_blank rel="noopener noreferrer" } |
     | Retags           | -10000 | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#retags){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | Bad Dual Groups  | -10000 | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups){: .header-icons target=_blank rel="noopener noreferrer" } |
     | DV (WEBDL)       | ?????? | [:octicons-link-external-16:](/Radarr/Radarr-collection-of-custom-formats/#dv-webdl){: .header-icons target=_blank rel="noopener noreferrer" } |
 
     ??? example "Breakdown and Why - [CLICK TO EXPAND]"
@@ -21,6 +22,8 @@
         - **No-RlsGroup:** [Optional] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
         - **Obfuscated:** [Optional] (use these only if you dislike renamed releases)
         - **Retags:** [Optional] (use these only if you dislike retagged releases)
+        - **Bad Dual Groups:** These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
+        Also they often even rename the release name in to Portuguese.
         - **DV (WEBDL):** This is a special Custom Format that Block WEBDL with Dolby Vision but without HDR10 fallback.
 
             This Custom Format works together with the normal DV Custom Format that you can use to prefer Dolby Vision.


### PR DESCRIPTION
- Added: [Sonarr] `Optional - Ignore Bad Dual Audio Groups` - These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
    Also they often even rename the release name in to Portuguese.
 - Added: [Radarr] CF `[Bad Dual Groups]` - These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
    Also they often even rename the release name in to Portuguese.