### PR TITLE
Radarr CF 20220804

### DIFF
--- a/docs/json/radarr/bad-dual-groups.json
+++ b/docs/json/radarr/bad-dual-groups.json
@@ -50,6 +50,15 @@
       }
     },
     {
+      "name": "EXTREME",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-EXTREME)\\b"
+      }
+    },
+    {
       "name": "FF",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/framestor.json
+++ b/docs/json/radarr/framestor.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "ff5bc9e8ce91d46c997ca3ac6994d6f8",
-  "trash_score": "51",
+  "trash_score": "101",
   "name": "FraMeSToR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bFraMeSToR\\b"
+        "value": "\\bFraMeSToR$"
       }
     }
   ]

--- a/docs/json/radarr/hq-remux.json
+++ b/docs/json/radarr/hq-remux.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "FraMeSToR"
+        "value": "FraMeSToR$"
       }
     },
     {

--- a/docs/json/radarr/uhd-legi0n.json
+++ b/docs/json/radarr/uhd-legi0n.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "4da96773192a51cf96178212642ca3bb",
-  "trash_score": "2100",
+  "trash_score": "2150",
   "name": "UHD (LEGi0N)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,9 @@
+# 2022-08-04
+Radarr CF 20220804 #695
+- Changed: Raised score for CF `[Framestore]`.
+- Added: regex to prevent download loop with bad dual groups. Issue: #685
+- Added: `EXTREME` to the CF `[Bad Dual Groups]`. Issue: #694
+
 # 2022-07-31
 Updated: Paste sites #690
 - Added: `Notifiarr.com`.

--- a/includes/cf/hq4k.md
+++ b/includes/cf/hq4k.md
@@ -6,5 +6,5 @@
     | UHD (W4NK3R)         | 2300  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-w4nk3r.json){: .header-icons target=_blank rel="noopener noreferrer" } |
     | UHD (SPHD)           | 2250  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-sphd.json){: .header-icons target=_blank rel="noopener noreferrer" } |
     | UHD (HQMUX)          | 2200  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-hqmux.json){: .header-icons target=_blank rel="noopener noreferrer" } |
-    | UHD (LEGi0N)         | 2100  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-legi0n.json){: .header-icons target=_blank rel="noopener noreferrer" } |
+    | UHD (LEGi0N)         | 2150  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-legi0n.json){: .header-icons target=_blank rel="noopener noreferrer" } |
     | UHD (WEBDV)          | 1800  | [:octicons-link-external-16:](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/uhd-webdv.json){: .header-icons target=_blank rel="noopener noreferrer" } |


### PR DESCRIPTION
- Changed: Raised score for CF `[Framestore]`.
- Added: regex to prevent download loop with bad dual groups. Issue: #685
- Added: `EXTREME` to the CF `[Bad Dual Groups]`. Issue: #694 