### PR TITLE
Update 4k Remaster

### DIFF
--- a/docs/json/radarr/4k-remaster.json
+++ b/docs/json/radarr/4k-remaster.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "Restoration",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "Restoration"
+      }
+    },
+    {
       "name": "4K",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
PtP uses `4k Restoration` as a synonym for `4k Remaster` this will catch that.