### PR TITLE
New metadata.json file with repo information

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 # EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
-root = false
+root = true
 
 [*.json]
 indent_style = space

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "metadata.schema.json",
+  "json_paths": {
+    "radarr": {
+      "custom_formats": ["docs/json/radarr"]
+    },
+    "sonarr": {
+      "release_profiles": ["docs/json/sonarr"]
+    }
+  }
+}

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/TRaSH-/Guides/master/metadata.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "json_paths": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "radarr": "#/$defs/radarr",
+        "sonarr": "#/$defs/sonarr"
+      }
+    }
+  },
+  "$defs": {
+    "release_profiles": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "custom_formats": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "radarr": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "custom_formats": "#/$defs/custom_formats"
+      }
+    },
+    "sonarr": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "release_profiles": "#/$defs/release_profiles"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently, tooling that references files in the Trash Guides github
repository has no reliable way to know where certain information lives.
For example, the Recyclarr application hard-codes paths (relative to the
repo root) to find the location of certain JSON files for Sonarr and
Radarr. Hard-coding paths is a poor practice because it limits the
ability for the Guides repository to be reorganized without breaking
tools.

This commit introduces a file named `metadata.json` that exists at the
root of the repository. Its sole purpose is to communicate information
about the repository itself. For now, the only thing this file provides
is the paths to JSON files for Radarr custom formats and Sonarr release
profiles.

This file will never move, otherwise we run into the same issue that
existed prior to having this file. When relevant files or directories
are reorganized in the repository, respective paths in `metadata.json`
will be updated which will allow tooling to continue to find needed
resources.

The catalyst for this change is that there has been discussion recently
about a new structure for JSON files in the repository due to the
introduction of Sonarr v4 JSON files.

Lastly, a schema has been provided to assist with live editing in
`metadata.json`. The schema file is named `metadata.schema.json`. Some
editors provide validation as you edit JSON files (e.g. VS Code), which
will take advantage of this.

Additional Changes:

* chore: Move .editorconfig to the repo root

  It doesn't exist yet as of this commit, but a set of new JSON files will
  be placed at the root of the repo and the editor config file is needed
  at the root of the repo to ensure proper formatting of those JSON files.