### PR TITLE
Fixed: Added word boundaries to `HQ` CFs

### DIFF
--- a/docs/json/radarr/hq-remux.json
+++ b/docs/json/radarr/hq-remux.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "3L\\b"
+        "value": "\\b3L\\b"
       }
     },
     {
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BiZKiT\\b"
+        "value": "\\bBiZKiT\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BLURANiUM\\b"
+        "value": "\\bBLURANiUM\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BMF\\b"
+        "value": "\\bBMF\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "decibeL\\b"
+        "value": "\\bdecibeL\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EPSiLON\\b"
+        "value": "-EPSiLON\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Flights\\b"
+        "value": "-Flights\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "FraMeSToR\\b"
+        "value": "\\bFraMeSToR\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HiFi\\b"
+        "value": "\\bHiFi\\b"
       }
     },
     {
@@ -100,7 +100,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "iFT\\b"
+        "value": "\\biFT\\b"
       }
     },
     {
@@ -109,7 +109,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "KRaLiMaRKo\\b"
+        "value": "\\bKRaLiMaRKo\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NCmt\\b"
+        "value": "\\bNCmt\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb\\b"
+        "value": "\\bNTb\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "playBD\\b"
+        "value": "\\bplayBD\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PmP\\b"
+        "value": "\\bPmP\\b"
       }
     },
     {
@@ -154,7 +154,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PTP\\b"
+        "value": "\\bPTP\\b"
       }
     },
     {
@@ -163,16 +163,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiCFoI\\b"
+        "value": "\\bSiCFoI\\b"
       }
     },
     {
-      "name": "Sumvision",
+      "name": "SumVision",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Sumvision\\b"
+        "value": "\\bSumVision\\b"
       }
     },
     {
@@ -181,7 +181,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SURFINBIRD\\b"
+        "value": "\\bSURFINBIRD\\b"
       }
     },
     {
@@ -190,7 +190,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TEPES\\b"
+        "value": "\\bTEPES\\b"
       }
     },
     {
@@ -199,7 +199,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TOA\\b"
+        "value": "\\bTOA\\b"
       }
     },
     {
@@ -208,16 +208,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TRiToN\\b"
+        "value": "-TRiToN\\b"
       }
     },
     {
-      "name": "Wildcat",
+      "name": "WiLDCAT",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Wildcat\\b"
+        "value": "-WiLDCAT\\b"
       }
     },
     {
@@ -226,7 +226,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ZQ\\b"
+        "value": "\\bZQ\\b"
       }
     }
   ]

--- a/docs/json/radarr/hq-webdl.json
+++ b/docs/json/radarr/hq-webdl.json
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ABBIE\\b"
+        "value": "-ABBIE\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "AJP69\\b"
+        "value": "\\bAJP69\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BLUTONiUM\\b"
+        "value": "\\bBLUTONiUM\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CMRG\\b"
+        "value": "\\bCMRG\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CRUD\\b"
+        "value": "\\bCRUD\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "dB\\b"
+        "value": "\\bdB\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Flights\\b"
+        "value": "-Flights\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "FLUX\\b"
+        "value": "-FLUX\\b"
       }
     },
     {
@@ -100,7 +100,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "GNOME\\b"
+        "value": "-GNOME\\b"
       }
     },
     {
@@ -109,7 +109,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "GNOMiSSiON\\b"
+        "value": "\\bGNOMiSSiON\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HONE\\b"
+        "value": "\\bHONE\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "KiNGS\\b"
+        "value": "-KiNGS\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "MiU\\b"
+        "value": "\\bMiU\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "monkee\\b"
+        "value": "\\bmonkee\\b"
       }
     },
     {
@@ -154,7 +154,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NOSiViD\\b"
+        "value": "\\bNOSiViD\\b"
       }
     },
     {
@@ -163,7 +163,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb\\b"
+        "value": "\\bNTb\\b"
       }
     },
     {
@@ -172,7 +172,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTG\\b"
+        "value": "\\bNTG\\b"
       }
     },
     {
@@ -181,7 +181,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PHOENiX\\b"
+        "value": "-PHOENiX\\b"
       }
     },
     {
@@ -190,7 +190,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ROCCaT\\b"
+        "value": "\\bROCCaT\\b"
       }
     },
     {
@@ -199,7 +199,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiC\\b"
+        "value": "\\bSiC\\b"
       }
     },
     {
@@ -208,7 +208,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiGMA\\b"
+        "value": "\\bSiGMA\\b"
       }
     },
     {
@@ -217,7 +217,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SLiGNOME\\b"
+        "value": "\\bSLiGNOME\\b"
       }
     },
     {
@@ -226,7 +226,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SMURF\\b"
+        "value": "-SMURF\\b"
       }
     },
     {
@@ -235,7 +235,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TEPES\\b"
+        "value": "-TEPES\\b"
       }
     },
     {
@@ -244,7 +244,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TOMMY\\b"
+        "value": "-TOMMY\\b"
       }
     }
   ]

--- a/docs/json/radarr/hq.json
+++ b/docs/json/radarr/hq.json
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BBQ\\b"
+        "value": "-BBQ\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BMF\\b"
+        "value": "\\bBMF\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "c0kE\\b"
+        "value": "\\bc0kE\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Chotab\\b"
+        "value": "\\bChotab\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CRiSC\\b"
+        "value": "\\bCRiSC\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CtrlHD\\b"
+        "value": "\\bCtrlHD\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "D-Z0N3\\b"
+        "value": "\\bD-Z0N3\\b"
       }
     },
     {
@@ -100,7 +100,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Dariush\\b"
+        "value": "\\bDariush\\b"
       }
     },
     {
@@ -109,7 +109,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "decibeL\\b"
+        "value": "\\bdecibeL\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "DON\\b"
+        "value": "-DON\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EA"
+        "value": "\\bEA\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EbP\\b"
+        "value": "\\bEbP\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EDPH\\b"
+        "value": "\\bEDPH\\b"
       }
     },
     {
@@ -154,7 +154,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Geek\\b"
+        "value": "-Geek\\b"
       }
     },
     {
@@ -163,7 +163,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HiSD"
+        "value": "\\bHiSD\\b"
       }
     },
     {
@@ -172,7 +172,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "iFT"
+        "value": "\\biFT\\b"
       }
     },
     {
@@ -181,7 +181,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "LolHD\\b"
+        "value": "\\bLolHD\\b"
       }
     },
     {
@@ -190,7 +190,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NCmt\\b"
+        "value": "\\bNCmt\\b"
       }
     },
     {
@@ -199,7 +199,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb"
+        "value": "\\bNTb\\b"
       }
     },
     {
@@ -208,7 +208,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PTer\\b"
+        "value": "\\bPTer\\b"
       }
     },
     {
@@ -217,7 +217,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "QOQ\\b"
+        "value": "\\bQOQ\\b"
       }
     },
     {
@@ -226,7 +226,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SA89"
+        "value": "\\bSA89\\b"
       }
     },
     {
@@ -235,7 +235,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "sbR"
+        "value": "\\bsbR\\b"
       }
     },
     {
@@ -244,7 +244,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TayTO\\b"
+        "value": "\\bTayTO\\b"
       }
     },
     {
@@ -253,7 +253,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TDD\\b"
+        "value": "\\bTDD\\b"
       }
     },
     {
@@ -262,7 +262,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TnP\\b"
+        "value": "\\bTnP\\b"
       }
     },
     {
@@ -271,7 +271,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "VietHD\\b"
+        "value": "\\bVietHD\\b"
       }
     },
     {
@@ -280,7 +280,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ZQ\\b"
+        "value": "\\bZQ\\b"
       }
     }
   ]


### PR DESCRIPTION
Added more word boundaries to the `HQ` custom formats to prevent incorrect matching of release groups to fix #710