### PR TITLE
Fixed: Word Boundaries for Tiered CFs

### DIFF
--- a/docs/json/radarr/hd-bluray-tier-01.json
+++ b/docs/json/radarr/hd-bluray-tier-01.json
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BBQ\\b"
+        "value": "\\b(BBQ)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BMF\\b"
+        "value": "\\b(BMF)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "c0kE\\b"
+        "value": "\\b(c0kE)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Chotab\\b"
+        "value": "\\b(Chotab)\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CRiSC\\b"
+        "value": "\\b(CRiSC)\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CtrlHD\\b"
+        "value": "\\b(CtrlHD)\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "D-Z0N3\\b"
+        "value": "\\b(D-Z0N3)\\b"
       }
     },
     {
@@ -100,7 +100,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Dariush\\b"
+        "value": "\\b(Dariush)\\b"
       }
     },
     {
@@ -109,7 +109,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "decibeL\\b"
+        "value": "\\b(decibeL)\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "DON\\b"
+        "value": "\\b(DON)\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EbP\\b"
+        "value": "\\b(EbP)\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EDPH\\b"
+        "value": "\\b(EDPH)\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Geek\\b"
+        "value": "\\b(Geek)\\b"
       }
     },
     {
@@ -154,7 +154,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "LolHD\\b"
+        "value": "\\b(LolHD)\\b"
       }
     },
     {
@@ -163,7 +163,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NCmt\\b"
+        "value": "\\b(NCmt)\\b"
       }
     },
     {
@@ -172,7 +172,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PTer\\b"
+        "value": "\\b(PTer)\\b"
       }
     },
     {
@@ -181,7 +181,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TayTO\\b"
+        "value": "\\b(TayTO)\\b"
       }
     },
     {
@@ -190,7 +190,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TDD\\b"
+        "value": "\\b(TDD)\\b"
       }
     },
     {
@@ -199,7 +199,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TnP\\b"
+        "value": "\\b(TnP)\\b"
       }
     },
     {
@@ -208,7 +208,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "VietHD\\b"
+        "value": "\\b(VietHD)\\b"
       }
     },
     {
@@ -217,7 +217,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ZQ\\b"
+        "value": "\\b(ZQ)\\b"
       }
     }
   ]

--- a/docs/json/radarr/hd-bluray-tier-02.json
+++ b/docs/json/radarr/hd-bluray-tier-02.json
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EA"
+        "value": "\\b(EA)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HiSD"
+        "value": "\\b(HiSD)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "iFT"
+        "value": "\\b(iFT)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb"
+        "value": "\\b(NTb)\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "QOQ\\b"
+        "value": "\\b(QOQ)\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SA89"
+        "value": "\\b(SA89)\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "sbR"
+        "value": "\\b(sbR)\\b"
       }
     }
   ]

--- a/docs/json/radarr/remux-tier-01.json
+++ b/docs/json/radarr/remux-tier-01.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "3L\\b"
+        "value": "\\b(3L)\\b"
       }
     },
     {
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BiZKiT\\b"
+        "value": "\\b(BiZKiT)\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BLURANiUM\\b"
+        "value": "\\b(BLURANiUM)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BMF\\b"
+        "value": "\\b(BMF)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "FraMeSToR\\b"
+        "value": "\\b(FraMeSToR)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PmP\\b"
+        "value": "\\b(PmP)\\b"
       }
     },
     {
@@ -73,16 +73,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiCFoI\\b"
+        "value": "\\b(SiCFoI)\\b"
       }
     },
     {
-      "name": "Wildcat",
+      "name": "WiLDCAT",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Wildcat\\b"
+        "value": "\\b(WiLDCAT)\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ZQ\\b"
+        "value": "\\b(ZQ)\\b"
       }
     }
   ]

--- a/docs/json/radarr/remux-tier-02.json
+++ b/docs/json/radarr/remux-tier-02.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "decibeL\\b"
+        "value": "\\b(decibeL)\\b"
       }
     },
     {
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "EPSiLON\\b"
+        "value": "\\b(EPSiLON)\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Flights\\b"
+        "value": "\\b(Flights)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HiFi\\b"
+        "value": "\\b(HiFi)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "iFT\\b"
+        "value": "\\b(iFT)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "KRaLiMaRKo\\b"
+        "value": "\\b(KRaLiMaRKo)\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NCmt\\b"
+        "value": "\\b(NCmt)\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb\\b"
+        "value": "\\b(NTb)\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "playBD\\b"
+        "value": "\\b(playBD)\\b"
       }
     },
     {
@@ -100,16 +100,16 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PTP\\b"
+        "value": "\\b(PTP)\\b"
       }
     },
     {
-      "name": "Sumvision",
+      "name": "SumVision",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Sumvision\\b"
+        "value": "\\b(SumVision)\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SURFINBIRD\\b"
+        "value": "\\b(SURFINBIRD)\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TEPES\\b"
+        "value": "\\b(TEPES)\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TOA\\b"
+        "value": "\\b(TOA)\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TRiToN\\b"
+        "value": "\\b(TRiToN)\\b"
       }
     }
   ]

--- a/docs/json/radarr/web-tier-01.json
+++ b/docs/json/radarr/web-tier-01.json
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ABBIE\\b"
+        "value": "\\b(ABBIE)\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "AJP69\\b"
+        "value": "\\b(AJP69)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "BLUTONiUM\\b"
+        "value": "\\b(BLUTONiUM)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CMRG\\b"
+        "value": "\\b(CMRG)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CRFW\\b"
+        "value": "\\b(CRFW)\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "CRUD\\b"
+        "value": "\\b(CRUD)\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "FLUX\\b"
+        "value": "\\b(FLUX)\\b"
       }
     },
     {
@@ -91,7 +91,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "GNOME\\b"
+        "value": "\\b(GNOME)\\b"
       }
     },
     {
@@ -100,7 +100,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "HONE\\b"
+        "value": "\\b(HONE)\\b"
       }
     },
     {
@@ -109,7 +109,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "KiNGS\\b"
+        "value": "\\b(KiNGS)\\b"
       }
     },
     {
@@ -118,7 +118,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NOSiViD\\b"
+        "value": "\\b(NOSiViD)\\b"
       }
     },
     {
@@ -127,7 +127,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTb\\b"
+        "value": "\\b(NTb)\\b"
       }
     },
     {
@@ -136,7 +136,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "NTG\\b"
+        "value": "\\b(NTG)\\b"
       }
     },
     {
@@ -145,7 +145,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiC\\b"
+        "value": "\\b(SiC)\\b"
       }
     },
     {
@@ -154,7 +154,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TEPES\\b"
+        "value": "\\b(TEPES)\\b"
       }
     }
   ]

--- a/docs/json/radarr/web-tier-02.json
+++ b/docs/json/radarr/web-tier-02.json
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "dB\\b"
+        "value": "\\b(dB)\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "Flights\\b"
+        "value": "\\b(Flights)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "MiU\\b"
+        "value": "\\b(MiU)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "monkee\\b"
+        "value": "\\b(monkee)\\b"
       }
     },
     {
@@ -64,7 +64,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "PHOENiX\\b"
+        "value": "\\b(PHOENiX)\\b"
       }
     },
     {
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SMURF\\b"
+        "value": "\\b(SMURF)\\b"
       }
     },
     {
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "TOMMY\\b"
+        "value": "\\b(TOMMY)\\b"
       }
     }
   ]

--- a/docs/json/radarr/web-tier-03.json
+++ b/docs/json/radarr/web-tier-03.json
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "GNOMiSSiON\\b"
+        "value": "\\b(GNOMiSSiON)\\b"
       }
     },
     {
@@ -37,7 +37,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "ROCCaT\\b"
+        "value": "\\b(ROCCaT)\\b"
       }
     },
     {
@@ -46,7 +46,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SiGMA\\b"
+        "value": "\\b(SiGMA)\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "SLiGNOME\\b"
+        "value": "\\b(SLiGNOME)\\b"
       }
     }
   ]


### PR DESCRIPTION
Added word boundaries for all the tiered CFs to prevent wrongfully matching another release group.