### PR TITLE
Updated anime CFs for Radarr and Sonarr

### DIFF
--- a/docs/json/radarr/anime/anime-10bit.json
+++ b/docs/json/radarr/anime/anime-10bit.json
@@ -1,0 +1,25 @@
+{
+  "trash_id": "c51ea28241f8d24e17bf0bf00ca32065",
+  "name": "Anime 10bit",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "10bit",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "10\\.?bit"
+      }
+    },
+    {
+      "name": "hi10p",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "hi10p"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-01-(top-seadex-muxers).json
+++ b/docs/json/radarr/anime/anime-bd-tier-01-(top-seadex-muxers).json
@@ -1,0 +1,107 @@
+{
+  "trash_id": "fb3ccc5d5cc8f77c9055d4cb4561dded",
+  "trash_score": "1400",
+  "name": "Anime BD Tier 01 (Top SeaDex Muxers)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "Aergia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Aergia\\]|-Aergia(?!-raws)\\b"
+      }
+    },
+    {
+      "name": "CsS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CsS)\\b"
+      }
+    },
+    {
+      "name": "Legion",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Legion\\]|-Legion\\b"
+      }
+    },
+    {
+      "name": "OZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(OZR)\\b"
+      }
+    },
+    {
+      "name": "sam",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[sam\\]|-sam\\b"
+      }
+    },
+    {
+      "name": "SCY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCY)\\b"
+      }
+    },
+    {
+      "name": "Spirale",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Spirale)\\b"
+      }
+    },
+    {
+      "name": "Vanilla",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vanilla\\]|-Vanilla\\b"
+      }
+    },
+    {
+      "name": "Vodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Vodes)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-02-(seadex-muxers).json
+++ b/docs/json/radarr/anime/anime-bd-tier-02-(seadex-muxers).json
@@ -1,0 +1,341 @@
+{
+  "trash_id": "66926c8fa9312bc74ab71bf69aae4f4a",
+  "trash_score": "1300",
+  "name": "Anime BD Tier 02 (SeaDex Muxers)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "0x539",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(0x539)\\b"
+      }
+    },
+    {
+      "name": "Alt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Alt\\]|-Alt\\b"
+      }
+    },
+    {
+      "name": "ARC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[ARC\\]|-ARC\\b"
+      }
+    },
+    {
+      "name": "Arid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Arid\\]|-Arid\\b"
+      }
+    },
+    {
+      "name": "aro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(aro)\\b"
+      }
+    },
+    {
+      "name": "Baws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Baws)\\b"
+      }
+    },
+    {
+      "name": "BKC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BKC)\\b"
+      }
+    },
+    {
+      "name": "Brrrrrrr",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Brrrrrrr)\\b"
+      }
+    },
+    {
+      "name": "Chotab",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Chotab)\\b"
+      }
+    },
+    {
+      "name": "Crow",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Crow\\]|-Crow\\b"
+      }
+    },
+    {
+      "name": "CUNNY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CUNNY)\\b"
+      }
+    },
+    {
+      "name": "D-Z0N3",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(D-Z0N3)\\b"
+      }
+    },
+    {
+      "name": "Dae",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Dae)\\b"
+      }
+    },
+    {
+      "name": "Datte13",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Datte13)\\b"
+      }
+    },
+    {
+      "name": "Drag",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Drag\\]|-Drag\\b"
+      }
+    },
+    {
+      "name": "FLFL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FLFL)\\b"
+      }
+    },
+    {
+      "name": "hydes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(hydes)\\b"
+      }
+    },
+    {
+      "name": "iKaos",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iKaos)\\b"
+      }
+    },
+    {
+      "name": "JySzE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(JySzE)\\b"
+      }
+    },
+    {
+      "name": "LostYears",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LostYears)\\b"
+      }
+    },
+    {
+      "name": "Lulu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Lulu\\]|-Lulu\\b"
+      }
+    },
+    {
+      "name": "Matsya",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Matsya)\\b"
+      }
+    },
+    {
+      "name": "MC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MC)\\b"
+      }
+    },
+    {
+      "name": "Metal",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Metal\\]|-Metal\\b"
+      }
+    },
+    {
+      "name": "Noyr",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Noyr)\\b"
+      }
+    },
+    {
+      "name": "NSDAB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NSDAB)\\b"
+      }
+    },
+    {
+      "name": "pog42",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(pog42)\\b"
+      }
+    },
+    {
+      "name": "pyroneko",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(pyroneko)\\b"
+      }
+    },
+    {
+      "name": "RAI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RAI)\\b"
+      }
+    },
+    {
+      "name": "Reza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reza)\\b"
+      }
+    },
+    {
+      "name": "Shimatta",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Shimatta)\\b"
+      }
+    },
+    {
+      "name": "Smoke",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Smoke\\]|-Smoke\\b"
+      }
+    },
+    {
+      "name": "Thighs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Thighs\\]|-Thighs\\b"
+      }
+    },
+    {
+      "name": "UDF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(UDF)\\b"
+      }
+    },
+    {
+      "name": "Yuki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yuki\\]|-Yuki\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-03-(seadex-muxers).json
+++ b/docs/json/radarr/anime/anime-bd-tier-03-(seadex-muxers).json
@@ -1,0 +1,305 @@
+{
+  "trash_id": "fa857662bad28d5ff21a6e611869a0ff",
+  "trash_score": "1200",
+  "name": "Anime BD Tier 03 (SeaDex Muxers)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "AC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[AC\\]|-AC\\b"
+      }
+    },
+    {
+      "name": "ASC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ASC)\\b"
+      }
+    },
+    {
+      "name": "AssMix",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AssMix)\\b"
+      }
+    },
+    {
+      "name": "Ayashii",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Ayashii)\\b"
+      }
+    },
+    {
+      "name": "CBT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CBT)\\b"
+      }
+    },
+    {
+      "name": "CTR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CTR)\\b"
+      }
+    },
+    {
+      "name": "CyC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CyC)\\b"
+      }
+    },
+    {
+      "name": "Dekinai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Dekinai\\]|-Dekinai\\b"
+      }
+    },
+    {
+      "name": "EXP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EXP\\]|-EXP\\b"
+      }
+    },
+    {
+      "name": "Galator",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Galator)\\b"
+      }
+    },
+    {
+      "name": "GSK_kun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GSK[._-]kun)\\b"
+      }
+    },
+    {
+      "name": "Holomux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Holomux)\\b"
+      }
+    },
+    {
+      "name": "IK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(IK)\\b"
+      }
+    },
+    {
+      "name": "Kaizoku",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeKaizoku)\\b|\\[Kaizoku\\]|-Kaizoku\\b"
+      }
+    },
+    {
+      "name": "Kametsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kametsu)\\b"
+      }
+    },
+    {
+      "name": "KH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KH)\\b"
+      }
+    },
+    {
+      "name": "kuchikirukia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(kuchikirukia)\\b"
+      }
+    },
+    {
+      "name": "MK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MK)\\b"
+      }
+    },
+    {
+      "name": "Mysteria",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Mysteria\\]|-Mysteria\\b"
+      }
+    },
+    {
+      "name": "Netaro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Netaro)\\b"
+      }
+    },
+    {
+      "name": "Pn8",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Pn8)\\b"
+      }
+    },
+    {
+      "name": "Pookie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Pookie)\\b"
+      }
+    },
+    {
+      "name": "Quetzal",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Quetzal)\\b"
+      }
+    },
+    {
+      "name": "Rasetsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Rasetsu)\\b"
+      }
+    },
+    {
+      "name": "Senjou",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Senjou\\]|-Senjou\\b"
+      }
+    },
+    {
+      "name": "ShowY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ShowY)\\b"
+      }
+    },
+    {
+      "name": "WBDP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WBDP)\\b"
+      }
+    },
+    {
+      "name": "WSE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WSE)\\b"
+      }
+    },
+    {
+      "name": "Yoghurt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Yoghurt)\\b"
+      }
+    },
+    {
+      "name": "YURI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[YURI\\]|-YURI\\b"
+      }
+    },
+    {
+      "name": "ZOIO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZOIO)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-04-(seadex-muxers).json
+++ b/docs/json/radarr/anime/anime-bd-tier-04-(seadex-muxers).json
@@ -1,0 +1,422 @@
+{
+  "trash_id": "f262f1299d99b1a2263375e8fa2ddbb3",
+  "trash_score": "1100",
+  "name": "Anime BD Tier 04 (SeaDex Muxers)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "deanzel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(deanzel)\\b"
+      }
+    },
+    {
+      "name": "ShadyCrab",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ShadyCrab)\\b"
+      }
+    },
+    {
+      "name": "hchcsen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(hchcsen)\\b"
+      }
+    },
+    {
+      "name": "NH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NH)\\b"
+      }
+    },
+    {
+      "name": "Chimera",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chimera\\]|-Chimera\\b"
+      }
+    },
+    {
+      "name": "Bulldog",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Bulldog\\]|-Bulldog\\b"
+      }
+    },
+    {
+      "name": "Foxtrot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Foxtrot\\]|-Foxtrot\\b"
+      }
+    },
+    {
+      "name": "Koten_Gars",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Koten[ ._-]Gars)\\b"
+      }
+    },
+    {
+      "name": "Kulot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kulot)\\b"
+      }
+    },
+    {
+      "name": "Asakura",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Asakura\\]|-Asakura\\b"
+      }
+    },
+    {
+      "name": "HaiveMind",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HaiveMind)\\b"
+      }
+    },
+    {
+      "name": "mottoj",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mottoj)\\b"
+      }
+    },
+    {
+      "name": "Bolshevik",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Bolshevik\\]|-Bolshevik\\b"
+      }
+    },
+    {
+      "name": "Scriptum",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Scriptum)\\b"
+      }
+    },
+    {
+      "name": "SOLA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SOLA\\]|-SOLA\\b"
+      }
+    },
+    {
+      "name": "NTRM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NTRM)\\b"
+      }
+    },
+    {
+      "name": "ASO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ASO)\\b"
+      }
+    },
+    {
+      "name": "MCLR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MCLR)\\b"
+      }
+    },
+    {
+      "name": "D3",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(D3)\\b"
+      }
+    },
+    {
+      "name": "AOmundson",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AOmundson)\\b"
+      }
+    },
+    {
+      "name": "RMX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RMX)\\b"
+      }
+    },
+    {
+      "name": "karios",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(karios)\\b"
+      }
+    },
+    {
+      "name": "xPearse",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(xPearse)\\b"
+      }
+    },
+    {
+      "name": "kBaraka",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(kBaraka)\\b"
+      }
+    },
+    {
+      "name": "SNSbu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SNSbu)\\b"
+      }
+    },
+    {
+      "name": "Orphan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Orphan\\]|-Orphan\\b"
+      }
+    },
+    {
+      "name": "Cait-Sidhe",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cait-Sidhe)\\b"
+      }
+    },
+    {
+      "name": "THORA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(THORA)\\b"
+      }
+    },
+    {
+      "name": "Davinci",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Davinci\\]|-Davinci\\b"
+      }
+    },
+    {
+      "name": "GHS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GHS)\\b"
+      }
+    },
+    {
+      "name": "Iznjie Biznjie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Iznjie[ .-]Biznjie)\\b"
+      }
+    },
+    {
+      "name": "9volt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(9volt)\\b"
+      }
+    },
+    {
+      "name": "Lia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Lia\\]|-Lia\\b"
+      }
+    },
+    {
+      "name": "kmplx",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(kmplx)\\b"
+      }
+    },
+    {
+      "name": "UWU",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(UWU)\\b"
+      }
+    },
+    {
+      "name": "Koitern",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Koitern)\\b"
+      }
+    },
+    {
+      "name": "MTBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MTBB)\\b"
+      }
+    },
+    {
+      "name": "Commie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Commie)\\b"
+      }
+    },
+    {
+      "name": "Kaleido",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaleido)\\b"
+      }
+    },
+    {
+      "name": "Doki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Doki\\]|-Doki\\b"
+      }
+    },
+    {
+      "name": "Tsundere",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Tsundere\\]|-Tsundere\\b"
+      }
+    },
+    {
+      "name": "Chihiro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chihiro\\]|-Chihiro\\b"
+      }
+    },
+    {
+      "name": "SallySubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SallySubs)\\b"
+      }
+    },
+    {
+      "name": "CoalGirls",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CoalGirls)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-05-(remuxes).json
+++ b/docs/json/radarr/anime/anime-bd-tier-05-(remuxes).json
@@ -1,0 +1,152 @@
+{
+  "trash_id": "ca864ed93c7b431150cc6748dc34875d",
+  "trash_score": "1000",
+  "name": "Anime BD Tier 05 (Remuxes)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "ANThELIa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ANThELIa)\\b"
+      }
+    },
+    {
+      "name": "AP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AP)\\b"
+      }
+    },
+    {
+      "name": "BluDragon",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BluDragon)\\b"
+      }
+    },
+    {
+      "name": "D4C",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(D4C)\\b"
+      }
+    },
+    {
+      "name": "Dragon-Releases",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Dragon-Releases)\\b"
+      }
+    },
+    {
+      "name": "E.N.D",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(E[.-]N[.-]D)\\b"
+      }
+    },
+    {
+      "name": "KAWAiREMUX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KAWAiREMUX)\\b"
+      }
+    },
+    {
+      "name": "MKVULTRA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MKVULTRA)\\b"
+      }
+    },
+    {
+      "name": "Raizel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Raizel)\\b"
+      }
+    },
+    {
+      "name": "REVO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(REVO)\\b"
+      }
+    },
+    {
+      "name": "Spark",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Spark\\]|-Spark\\b"
+      }
+    },
+    {
+      "name": "SRLS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SRLS)\\b"
+      }
+    },
+    {
+      "name": "TTGA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TTGA)\\b"
+      }
+    },
+    {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-06-(fansubs).json
+++ b/docs/json/radarr/anime/anime-bd-tier-06-(fansubs).json
@@ -1,0 +1,359 @@
+{
+  "trash_id": "9dce189b960fddf47891b7484ee886ca",
+  "trash_score": "900",
+  "name": "Anime BD Tier 06 (FanSubs)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "Afro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Afro\\]|-Afro\\b"
+      }
+    },
+    {
+      "name": "Akai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Akai\\]|-Akai\\b"
+      }
+    },
+    {
+      "name": "Almighty",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Almighty\\]|-Almighty\\b"
+      }
+    },
+    {
+      "name": "ANE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ANE)\\b"
+      }
+    },
+    {
+      "name": "Asenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Asenshi)\\b"
+      }
+    },
+    {
+      "name": "BlurayDesuYo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlurayDesuYo)\\b"
+      }
+    },
+    {
+      "name": "Bunny-Apocalypse",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Bunny-Apocalypse)\\b"
+      }
+    },
+    {
+      "name": "CH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CH)\\b"
+      }
+    },
+    {
+      "name": "EJF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(EJF)\\b"
+      }
+    },
+    {
+      "name": "Exiled-Destiny",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Exiled-Destiny|E-D)\\b"
+      }
+    },
+    {
+      "name": "FFF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FFF)\\b"
+      }
+    },
+    {
+      "name": "Final8",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Final8)\\b"
+      }
+    },
+    {
+      "name": "GS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GS)\\b"
+      }
+    },
+    {
+      "name": "Harunatsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Harunatsu\\]|-Harunatsu\\b"
+      }
+    },
+    {
+      "name": "Impatience",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Impatience\\]|-Impatience\\b"
+      }
+    },
+    {
+      "name": "Inka-Subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Inka-Subs)\\b"
+      }
+    },
+    {
+      "name": "Judgement",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Judgment\\]|-Judgment\\b"
+      }
+    },
+    {
+      "name": "Kantai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kantai\\]|-Kantai\\b"
+      }
+    },
+    {
+      "name": "LCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LCE)\\b"
+      }
+    },
+    {
+      "name": "Licca",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Licca)\\b"
+      }
+    },
+    {
+      "name": "Nii-sama",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Nii-sama\\]|-Nii-sama\\b"
+      }
+    },
+    {
+      "name": "niizk",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(niizk)\\b"
+      }
+    },
+    {
+      "name": "Nishi-Taku",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nishi-Taku)\\b"
+      }
+    },
+    {
+      "name": "OnDeed",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(OnDeed)\\b"
+      }
+    },
+    {
+      "name": "orz",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(orz)\\b"
+      }
+    },
+    {
+      "name": "PAS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PAS)\\b"
+      }
+    },
+    {
+      "name": "peachflavored",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(peachflavored)\\b"
+      }
+    },
+    {
+      "name": "Saizen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Saizen)\\b"
+      }
+    },
+    {
+      "name": "SCP-2223",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCP-2223)\\b"
+      }
+    },
+    {
+      "name": "SHiN-gx",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SHiN-gx)\\b"
+      }
+    },
+    {
+      "name": "SmugCat",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SmugCat)\\b"
+      }
+    },
+    {
+      "name": "Soldado",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Soldado\\]|-Soldado\\b"
+      }
+    },
+    {
+      "name": "Sushi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Sushi\\]|-Sushi\\b"
+      }
+    },
+    {
+      "name": "Vivid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vivid\\]|-Vivid\\b"
+      }
+    },
+    {
+      "name": "Watashi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Watashi\\]|-Watashi\\b"
+      }
+    },
+    {
+      "name": "Yabai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yabai\\]|-Yabai\\b"
+      }
+    },
+    {
+      "name": "Zurako",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Zurako)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-07-(p2pscene).json
+++ b/docs/json/radarr/anime/anime-bd-tier-07-(p2pscene).json
@@ -1,0 +1,197 @@
+{
+  "trash_id": "1ef101b3a82646b40e0cab7fc92cd896",
+  "trash_score": "800",
+  "name": "Anime BD Tier 07 (P2P/Scene)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "A-L",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(A-L)\\b"
+      }
+    },
+    {
+      "name": "ANiHLS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ANiHLS)\\b"
+      }
+    },
+    {
+      "name": "BMF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BMF)\\b"
+      }
+    },
+    {
+      "name": "CBM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CBM)\\b"
+      }
+    },
+    {
+      "name": "DHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DHD)\\b"
+      }
+    },
+    {
+      "name": "DragsterPS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DragsterPS)\\b"
+      }
+    },
+    {
+      "name": "HAiKU",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HAiKU)\\b"
+      }
+    },
+    {
+      "name": "Hark0N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hark0N)\\b"
+      }
+    },
+    {
+      "name": "iAHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iAHD)\\b"
+      }
+    },
+    {
+      "name": "inid4c",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(inid4c)\\b"
+      }
+    },
+    {
+      "name": "KS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KS)\\b"
+      }
+    },
+    {
+      "name": "MCR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MCR)\\b"
+      }
+    },
+    {
+      "name": "NPC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[NPC\\]|-NPC\\b"
+      }
+    },
+    {
+      "name": "RedBlade",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RedBlade)\\b"
+      }
+    },
+    {
+      "name": "RH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RH)\\b"
+      }
+    },
+    {
+      "name": "SEV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SEV)\\b"
+      }
+    },
+    {
+      "name": "STRiFE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[STRiFE\\]|-STRiFE\\b"
+      }
+    },
+    {
+      "name": "TENEIGHTY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TENEIGHTY)\\b"
+      }
+    },
+    {
+      "name": "WaLMaRT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WaLMaRT)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-bd-tier-08-(mini-encodes).json
+++ b/docs/json/radarr/anime/anime-bd-tier-08-(mini-encodes).json
@@ -1,0 +1,125 @@
+{
+  "trash_id": "6115ccd6640b978234cc47f2c1f2cadc",
+  "trash_score": "700",
+  "name": "Anime BD Tier 08 (Mini Encodes)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 9
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "AkihitoSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AkihitoSubs)\\b"
+      }
+    },
+    {
+      "name": "Arukoru",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Arukoru)\\b"
+      }
+    },
+    {
+      "name": "EDGE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EDGE\\]|-EDGE\\b"
+      }
+    },
+    {
+      "name": "EMBER",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EMBER\\]|-EMBER\\b"
+      }
+    },
+    {
+      "name": "GHOST",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[GHOST\\]|-GHOST\\b"
+      }
+    },
+    {
+      "name": "Judas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Judas\\]|-Judas"
+      }
+    },
+    {
+      "name": "naiyas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[naiyas\\]|-naiyas\\b"
+      }
+    },
+    {
+      "name": "Nep_Blanc",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nep[ ._-]Blanc)\\b"
+      }
+    },
+    {
+      "name": "Prof",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Prof\\]|-Prof\\b"
+      }
+    },
+    {
+      "name": "Shirσ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Shirσ)\\b"
+      }
+    },
+    {
+      "name": "YURASAKA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[YURASUKA\\]|-YURASUKA\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-dual-audio.json
+++ b/docs/json/radarr/anime/anime-dual-audio.json
@@ -1,0 +1,25 @@
+{
+  "trash_id": "4c7cb69b3355b3347c81d7d1b7f95326",
+  "name": "Anime Dual Audio",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Dual Audio",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "dual[ ._-]?audio|\\[dual\\]|(EN|JA)\\+(JA|EN)"
+      }
+    },
+    {
+      "name": "Not Japanese Only",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\[JA\\]"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-dubs-only.json
+++ b/docs/json/radarr/anime/anime-dubs-only.json
@@ -1,0 +1,62 @@
+{
+  "trash_id": "b08bdc0056a7b73a589da72e73369d20",
+  "trash_score": "-10000",
+  "name": "Anime Dubs Only",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Dubbed",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(dub(bed)?)\\b|(funi|eng(lish)?)_?dub"
+      }
+    },
+    {
+      "name": "Golumpa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Golumpa)\\b"
+      }
+    },
+    {
+      "name": "KaiDubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KaiDubs)\\b"
+      }
+    },
+    {
+      "name": "KamiFS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KamiFS)\\b"
+      }
+    },
+    {
+      "name": "KS (Not Dual Audio)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?!.*Dual[-_. ]?Audio).*\\bKS\\b"
+      }
+    },
+    {
+      "name": "torenter69",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(torenter69)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-lq-groups.json
+++ b/docs/json/radarr/anime/anime-lq-groups.json
@@ -1,0 +1,1214 @@
+{
+  "trash_id": "b0fdc5897f68c9a68c70c25169f77447",
+  "trash_score": "-10000",
+  "name": "Anime LQ Groups",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "$tore-Chill",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(\\$tore-Chill)\\b"
+      }
+    },
+    {
+      "name": "0neshot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(0neshot)\\b"
+      }
+    },
+    {
+      "name": "224",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[224\\]|-224\\b"
+      }
+    },
+    {
+      "name": "A-Destiny",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(A-Destiny)\\b"
+      }
+    },
+    {
+      "name": "AbemaTV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AbemaTV)\\b"
+      }
+    },
+    {
+      "name": "AceAres",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AceAres)\\b"
+      }
+    },
+    {
+      "name": "AhmadDev",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AhmadDev)\\b"
+      }
+    },
+    {
+      "name": "Amb3r",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Amb3r)\\b"
+      }
+    },
+    {
+      "name": "Anime Chap",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Chap)\\b"
+      }
+    },
+    {
+      "name": "Anime Land",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Land)\\b"
+      }
+    },
+    {
+      "name": "Anime Time",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Time)\\b"
+      }
+    },
+    {
+      "name": "AnimeDynastyEN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeDynastyEN)\\b"
+      }
+    },
+    {
+      "name": "AnimeKuro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeKuro)\\b"
+      }
+    },
+    {
+      "name": "AnimeRG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeRG)\\b"
+      }
+    },
+    {
+      "name": "Animesubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Animesubs)\\b"
+      }
+    },
+    {
+      "name": "AnimeTR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeTR)\\b"
+      }
+    },
+    {
+      "name": "AniVoid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AniVoid)\\b"
+      }
+    },
+    {
+      "name": "ArataEnc",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ArataEnc)\\b"
+      }
+    },
+    {
+      "name": "AREY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AREY)\\b"
+      }
+    },
+    {
+      "name": "Ari",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Ari\\]|-Ari\\b"
+      }
+    },
+    {
+      "name": "ASW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ASW)\\b"
+      }
+    },
+    {
+      "name": "BJX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BJX)\\b"
+      }
+    },
+    {
+      "name": "BlackLuster",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackLuster)\\b"
+      }
+    },
+    {
+      "name": "bonkai77",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(bonkai77)\\b"
+      }
+    },
+    {
+      "name": "CameEsp",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CameEsp)\\b"
+      }
+    },
+    {
+      "name": "Cat66",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cat66)\\b"
+      }
+    },
+    {
+      "name": "CBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CBB)\\b"
+      }
+    },
+    {
+      "name": "Cerberus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cerberus\\]|-Cerberus\\b"
+      }
+    },
+    {
+      "name": "Cleo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cleo\\]|-Cleo"
+      }
+    },
+    {
+      "name": "CuaP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CuaP)\\b"
+      }
+    },
+    {
+      "name": "DaddySubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Daddy(Subs)?\\]|-Daddy(Subs)?\\b"
+      }
+    },
+    {
+      "name": "DARKFLiX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DARKFLiX)\\b"
+      }
+    },
+    {
+      "name": "DB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[DB\\]"
+      }
+    },
+    {
+      "name": "DBArabic",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DBArabic)\\b"
+      }
+    },
+    {
+      "name": "Deadmau- RAWS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Deadmau[ .-]?[ .-]?RAWS)\\b"
+      }
+    },
+    {
+      "name": "DKB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DKB)\\b"
+      }
+    },
+    {
+      "name": "DP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DP)\\b"
+      }
+    },
+    {
+      "name": "DsunS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DsunS)\\b"
+      }
+    },
+    {
+      "name": "ExREN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ExREN)\\b"
+      }
+    },
+    {
+      "name": "FAV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[FAV\\]|-FAV\\b"
+      }
+    },
+    {
+      "name": "Fish",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b((Baked|Dead|Space)Fish)\\b"
+      }
+    },
+    {
+      "name": "FunArts",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FunArts)\\b"
+      }
+    },
+    {
+      "name": "GERMini",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GERMini)\\b"
+      }
+    },
+    {
+      "name": "Hakata Ramen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hakata[ .-]?Ramen)\\b"
+      }
+    },
+    {
+      "name": "Hall_of_C",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hall_of_C)\\b"
+      }
+    },
+    {
+      "name": "Hatsuyuki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Hatsuyuki\\]|-Hatsuyuki\\b"
+      }
+    },
+    {
+      "name": "HAV1T",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HAV1T)\\b"
+      }
+    },
+    {
+      "name": "HENiL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HENiL)\\b"
+      }
+    },
+    {
+      "name": "Hitoku",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Hitoku\\]|-Hitoki\\b"
+      }
+    },
+    {
+      "name": "HollowRoxas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HollowRoxas)\\b"
+      }
+    },
+    {
+      "name": "HR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HR)\\b"
+      }
+    },
+    {
+      "name": "ICEBLUE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ICEBLUE)\\b"
+      }
+    },
+    {
+      "name": "iPUNISHER",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iPUNISHER)\\b"
+      }
+    },
+    {
+      "name": "JacobSwaggedUp",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(JacobSwaggedUp)\\b"
+      }
+    },
+    {
+      "name": "Johnny-englishsubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Johnny-englishsubs)\\b"
+      }
+    },
+    {
+      "name": "Kaerizaki-Fansub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaerizaki-Fansub)\\b"
+      }
+    },
+    {
+      "name": "Kanjouteki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kanjouteki)\\b"
+      }
+    },
+    {
+      "name": "KEKMASTERS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KEKMASTERS)\\b"
+      }
+    },
+    {
+      "name": "Kirion",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kirion)\\b"
+      }
+    },
+    {
+      "name": "KRP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KRP)\\b"
+      }
+    },
+    {
+      "name": "LoliHouse",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LoliHouse)\\b"
+      }
+    },
+    {
+      "name": "M@nI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(M@nI)\\b"
+      }
+    },
+    {
+      "name": "mal lu zen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mal[ .-]lu[ .-]zen)\\b"
+      }
+    },
+    {
+      "name": "Man.K",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Man\\.K)\\b"
+      }
+    },
+    {
+      "name": "Maximus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Maximus\\]|-Maximus\\b"
+      }
+    },
+    {
+      "name": "MD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[MD\\]|-MD\\b"
+      }
+    },
+    {
+      "name": "mdcx",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mdcx)\\b"
+      }
+    },
+    {
+      "name": "Metaljerk",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Metaljerk)\\b"
+      }
+    },
+    {
+      "name": "MGD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MGD)\\b"
+      }
+    },
+    {
+      "name": "MiniFreeza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MiniFreeza)\\b"
+      }
+    },
+    {
+      "name": "MinisCuba",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MinisCuba)\\b"
+      }
+    },
+    {
+      "name": "MiniTheatre",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MiniTheatre)\\b"
+      }
+    },
+    {
+      "name": "Mites",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mites)\\b"
+      }
+    },
+    {
+      "name": "Modders Bay",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Modders[ .-]?Bay)\\b"
+      }
+    },
+    {
+      "name": "Mr. Deadpool",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mr\\.Deadpool)\\b"
+      }
+    },
+    {
+      "name": "NemDiggers",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NemDiggers)\\b"
+      }
+    },
+    {
+      "name": "neoHEVC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(neoHEVC)\\b"
+      }
+    },
+    {
+      "name": "Nokou",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nokou)\\b"
+      }
+    },
+    {
+      "name": "NoobSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(N[eo][wo]b[ ._-]?Subs)\\b"
+      }
+    },
+    {
+      "name": "NS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NS)\\b"
+      }
+    },
+    {
+      "name": "Nyanpasu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nyanpasu)\\b"
+      }
+    },
+    {
+      "name": "OldCastle",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(OldCastle)\\b"
+      }
+    },
+    {
+      "name": "Pantsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pantsu\\]|-Pantsu\\b"
+      }
+    },
+    {
+      "name": "Pao",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pao\\]|-Pao\\b"
+      }
+    },
+    {
+      "name": "phazer11",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(phazer11)\\b"
+      }
+    },
+    {
+      "name": "Pixel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pixel\\]|-Pixel\\b"
+      }
+    },
+    {
+      "name": "Plex Friendly",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Plex[ .-]?Friendly)\\b"
+      }
+    },
+    {
+      "name": "PnPSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PnPSubs)\\b"
+      }
+    },
+    {
+      "name": "Polarwindz",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Polarwindz)\\b"
+      }
+    },
+    {
+      "name": "Project-gxs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Project-gxs)\\b"
+      }
+    },
+    {
+      "name": "PuyaSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PuyaSubs)\\b"
+      }
+    },
+    {
+      "name": "QaS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(QAS)\\b"
+      }
+    },
+    {
+      "name": "QCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(QCE)\\b"
+      }
+    },
+    {
+      "name": "Rando235",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Rando235)\\b"
+      }
+    },
+    {
+      "name": "Ranger",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Ranger\\]|-Ranger\\b"
+      }
+    },
+    {
+      "name": "Rapta",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Rapta\\]|-Rapta\\b"
+      }
+    },
+    {
+      "name": "Raw Files",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(M2TS|BDMV|BDVD)\\b"
+      }
+    },
+    {
+      "name": "Raze",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Raze\\]|-Raze\\b"
+      }
+    },
+    {
+      "name": "Reaktor",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reaktor)\\b"
+      }
+    },
+    {
+      "name": "RightShiftBy2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RightShiftBy2)\\b"
+      }
+    },
+    {
+      "name": "Rip Time",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Rip[ .-]?Time)\\b"
+      }
+    },
+    {
+      "name": "SAD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SAD\\]|-SAD\\b"
+      }
+    },
+    {
+      "name": "Salieri",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Salieri)\\b"
+      }
+    },
+    {
+      "name": "Samir755",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Samir755)\\b"
+      }
+    },
+    {
+      "name": "SanKyuu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SanKyuu)\\b"
+      }
+    },
+    {
+      "name": "SEiN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SEiN\\]|-SEiN\\b"
+      }
+    },
+    {
+      "name": "sekkusu&ok",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(sekkusu&ok)\\b"
+      }
+    },
+    {
+      "name": "SHFS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SHFS)\\b"
+      }
+    },
+    {
+      "name": "SLAX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SLAX)\\b"
+      }
+    },
+    {
+      "name": "SRW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SRW)\\b"
+      }
+    },
+    {
+      "name": "SSA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SSA)\\b"
+      }
+    },
+    {
+      "name": "StrayGods",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(StrayGods)\\b"
+      }
+    },
+    {
+      "name": "Suki Desu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Suki[ .-]?Desu\\]|-Suki[ .-]?Desu\\b"
+      }
+    },
+    {
+      "name": "TeamTurquoize",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TeamTurquoize)\\b"
+      }
+    },
+    {
+      "name": "Tenrai Sensei",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Tenrai[ .-]?Sensei)\\b"
+      }
+    },
+    {
+      "name": "TnF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TnF)\\b"
+      }
+    },
+    {
+      "name": "TOPKEK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TOPKEK)\\b"
+      }
+    },
+    {
+      "name": "Trix",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Trix\\]|-Trix\\b"
+      }
+    },
+    {
+      "name": "U3-Web",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(U3-Web)\\b"
+      }
+    },
+    {
+      "name": "UNBIASED",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[UNBIASED\\]|-UNBIASED\\b"
+      }
+    },
+    {
+      "name": "USD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[USD\\]|-USD\\b"
+      }
+    },
+    {
+      "name": "Valenciano",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Valenciano)\\b"
+      }
+    },
+    {
+      "name": "VipapkStudios",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(VipapkStudios)\\b"
+      }
+    },
+    {
+      "name": "VOSTFR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(VOSTFR)\\b"
+      }
+    },
+    {
+      "name": "Wardevil",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Wardevil\\]|-Wardevil\\b"
+      }
+    },
+    {
+      "name": "WtF Anime",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WtF[ ._-]?Anime)\\b"
+      }
+    },
+    {
+      "name": "xiao-av1",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(xiao-av1)\\b"
+      }
+    },
+    {
+      "name": "Yabai_Desu_NeRandomRemux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Yabai_Desu_NeRandomRemux)\\b"
+      }
+    },
+    {
+      "name": "YakuboEncodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(YakuboEncodes)\\b"
+      }
+    },
+    {
+      "name": "Yameii",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yameii\\]|-Yameii\\b"
+      }
+    },
+    {
+      "name": "youshikibi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(youshikibi)\\b"
+      }
+    },
+    {
+      "name": "YuiSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(YuiSubs)\\b"
+      }
+    },
+    {
+      "name": "Yun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yun\\]|-Yun\\b"
+      }
+    },
+    {
+      "name": "zza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[zza\\]|-zza\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-raws.json
+++ b/docs/json/radarr/anime/anime-raws.json
@@ -1,0 +1,125 @@
+{
+  "trash_id": "06b6542a47037d1e33b15aa3677c2365",
+  "trash_score": "-10000",
+  "name": "Anime Raws",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Beatrice-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Beatrice[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Daddy-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Daddy[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Iriza-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Iriza[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Kawaiika-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Kawaiika[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "km",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[km\\]|-km\\b "
+      }
+    },
+    {
+      "name": "LowPower-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "LowPower[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "NC-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "NC[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "neko-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "neko[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Ohys-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Ohys[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Pandoratv-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Pandoratv[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Raws-Maji",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Raws-Maji)\\b"
+      }
+    },
+    {
+      "name": "Scryous-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Scryous[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Seicher",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Seicher)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-v0.json
+++ b/docs/json/radarr/anime/anime-v0.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "36a6d1ebb6ccb287894387a096715530",
+  "trash_score": "-51",
+  "name": "Anime v0",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<=(\\d|\\[))(v0)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-v1.json
+++ b/docs/json/radarr/anime/anime-v1.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "8b2455cc2c68c59f75657e4d35f973b9",
+  "trash_score": "1",
+  "name": "Anime v1",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v1",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\d|\\[)(v1)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-v2.json
+++ b/docs/json/radarr/anime/anime-v2.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "9522e1290616bcf59553f0a801992019",
+  "trash_score": "2",
+  "name": "Anime v2",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<=(\\d|\\[))(v2)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-v3.json
+++ b/docs/json/radarr/anime/anime-v3.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "b6c581b5879889e619a4ffef3f30faf2",
+  "trash_score": "3",
+  "name": "Anime v3",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v3",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<=(\\d|\\[))(v3)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-v4.json
+++ b/docs/json/radarr/anime/anime-v4.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "51e170088fb933ee29e4a1344d0ef982",
+  "trash_score": "4",
+  "name": "Anime v4",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v4",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<=(\\d|\\[))(v4)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-vrv.json
+++ b/docs/json/radarr/anime/anime-vrv.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "5eea67eac4646d6a60de110ad8bc429b",
+  "trash_score": "10",
+  "name": "Anime VRV",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "VRV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(vrv)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-01-(muxers).json
+++ b/docs/json/radarr/anime/anime-web-tier-01-(muxers).json
@@ -1,0 +1,98 @@
+{
+  "trash_id": "8167cffba4febfb9a6988ef24f274e7e",
+  "trash_score": "600",
+  "name": "Anime Web Tier 01 (Muxers)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "Arid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Arid\\]|-Arid\\b"
+      }
+    },
+    {
+      "name": "Baws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Baws)\\b"
+      }
+    },
+    {
+      "name": "LostYears",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LostYears)\\b"
+      }
+    },
+    {
+      "name": "Reza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reza)\\b"
+      }
+    },
+    {
+      "name": "SCY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCY)\\b"
+      }
+    },
+    {
+      "name": "Setsugen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Setsugen)\\b"
+      }
+    },
+    {
+      "name": "Vodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Vodes)\\b"
+      }
+    },
+    {
+      "name": "Z4ST1N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Z4ST1N)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-02-(top-fansubs).json
+++ b/docs/json/radarr/anime/anime-web-tier-02-(top-fansubs).json
@@ -1,0 +1,143 @@
+{
+  "trash_id": "8526c54e36b4962d340fce52ef030e76",
+  "trash_score": "500",
+  "name": "Anime Web Tier 02 (Top FanSubs)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "0x539",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(0x539)\\b"
+      }
+    },
+    {
+      "name": "Asakura",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Asakura\\]|-Asakura\\b"
+      }
+    },
+    {
+      "name": "Cyan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cyan\\]|-Cyan\\b"
+      }
+    },
+    {
+      "name": "Dae",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Dae\\]|-Dae\\b"
+      }
+    },
+    {
+      "name": "Foxtrot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Foxtrot\\]|-Foxtrot\\b"
+      }
+    },
+    {
+      "name": "Gao",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Gao\\]|-Gao\\b"
+      }
+    },
+    {
+      "name": "GSK_kun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GSK[._-]kun)\\b"
+      }
+    },
+    {
+      "name": "MTBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MTBB)\\b"
+      }
+    },
+    {
+      "name": "Okay-Subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Okay-Subs)\\b"
+      }
+    },
+    {
+      "name": "Pizza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pizza\\]|-Pizza\\b"
+      }
+    },
+    {
+      "name": "Slyfox",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Slyfox)\\b"
+      }
+    },
+    {
+      "name": "SoLCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SoLCE)\\b"
+      }
+    },
+    {
+      "name": "Tenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[tenshi\\]|-tenshi\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-03-(subsplease).json
+++ b/docs/json/radarr/anime/anime-web-tier-03-(subsplease).json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "5b1a5d3df27396373b4ce236fc337eaa",
+  "trash_score": "400",
+  "name": "Anime Web Tier 03 (SubsPlease)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "SubsPlease",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SubsPlease)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-04-(official-subs).json
+++ b/docs/json/radarr/anime/anime-web-tier-04-(official-subs).json
@@ -1,0 +1,125 @@
+{
+  "trash_id": "9edaeee9ea3bcd585da9b7c0ac3fc54f",
+  "trash_score": "300",
+  "name": "Anime Web Tier 04 (Official Subs)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "BlueLobster",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlueLobster)\\b"
+      }
+    },
+    {
+      "name": "Erai-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Erai-raws)\\b"
+      }
+    },
+    {
+      "name": "GST",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GST)\\b"
+      }
+    },
+    {
+      "name": "HorribleRips",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HorribleRips)\\b"
+      }
+    },
+    {
+      "name": "HorribleSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HorribleSubs)\\b"
+      }
+    },
+    {
+      "name": "KAN3D2M",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KAN3D2M)\\b"
+      }
+    },
+    {
+      "name": "KiyoshiStar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KiyoshiStar)\\b"
+      }
+    },
+    {
+      "name": "Lia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Lia\\]|-Lia\\b"
+      }
+    },
+    {
+      "name": "NanDesuKa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NanDesuKa)\\b"
+      }
+    },
+    {
+      "name": "URANIME",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(URANIME)\\b"
+      }
+    },
+    {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-05-(fansubs).json
+++ b/docs/json/radarr/anime/anime-web-tier-05-(fansubs).json
@@ -1,0 +1,62 @@
+{
+  "trash_id": "22d953bbe897857b517928f3652b8dd3",
+  "trash_score": "200",
+  "name": "Anime Web Tier 05 (FanSubs)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "9volt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(9volt)\\b"
+      }
+    },
+    {
+      "name": "GJM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GJM)\\b"
+      }
+    },
+    {
+      "name": "Kaleido",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaleido)\\b"
+      }
+    },
+    {
+      "name": "Kantai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kantai\\]|-Kantai\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/anime/anime-web-tier-06-(fansubs).json
+++ b/docs/json/radarr/anime/anime-web-tier-06-(fansubs).json
@@ -1,0 +1,80 @@
+{
+  "trash_id": "a786fbc0eae05afe3bb51aee3c83a9d4",
+  "trash_score": "100",
+  "name": "Anime Web Tier 06 (FanSubs)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "Asenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Asenshi)\\b"
+      }
+    },
+    {
+      "name": "Chihiro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chihiro\\]|-Chihiro\\b"
+      }
+    },
+    {
+      "name": "Commie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Commie)\\b"
+      }
+    },
+    {
+      "name": "DameDesuYo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DameDesuYo)\\b"
+      }
+    },
+    {
+      "name": "Doki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Doki\\]|-Doki\\b"
+      }
+    },
+    {
+      "name": "Tsundere",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Tsundere\\]|-Tsundere\\b"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/anime/anime-10bit.json
+++ b/docs/json/sonarr/cf/anime/anime-10bit.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "c77040cde7b8232ab284cd8b2ec9d3e4",
+  "trash_id": "6b09c09ca85a4c3d22fdb1fa8e74508d",
   "name": "Anime 10bit",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-01-(top-seadex-muxers).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-01-(top-seadex-muxers).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "d113746a2e8c36975145e0b367353fb3",
+  "trash_id": "949c16fe0a8147f50ba82cc2df9411c9",
   "trash_score": "1400",
   "name": "Anime BD Tier 01 (Top SeaDex Muxers)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-02-(seadex-muxers).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-02-(seadex-muxers).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "efab81a02e4e5a978d1525097527dea8",
+  "trash_id": "ed7f1e315e000aef424a58517fa48727",
   "trash_score": "1300",
   "name": "Anime BD Tier 02 (SeaDex Muxers)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-03-(seadex-muxers).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-03-(seadex-muxers).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "f2f3572cf9d004beea34517b16782357",
+  "trash_id": "096e406c92baa713da4a72d88030b815",
   "trash_score": "1200",
   "name": "Anime BD Tier 03 (SeaDex Muxers)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-04-(seadex-muxers).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-04-(seadex-muxers).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "987961d4b56fa6bb60dc92e8dc93c5be",
+  "trash_id": "30feba9da3030c5ed1e0f7d610bcadc4",
   "trash_score": "1100",
   "name": "Anime BD Tier 04 (SeaDex Muxers)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-05-(remuxes).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-05-(remuxes).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "95cd51aa5e3739ef089c31bb446d0a8a",
+  "trash_id": "545a76b14ddc349b8b185a6344e28b04",
   "trash_score": "1000",
   "name": "Anime BD Tier 05 (Remuxes)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-06-(fansubs).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-06-(fansubs).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "0ac47c05645c3f3f5930df661a3540c7",
+  "trash_id": "25d2afecab632b1582eaf03b63055f72",
   "trash_score": "900",
   "name": "Anime BD Tier 06 (FanSubs)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-07-(p2pscene).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-07-(p2pscene).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "06b3a88f503e22e8ab4a18fe06048725",
+  "trash_id": "0329044e3d9137b08502a9f84a7e58db",
   "trash_score": "800",
   "name": "Anime BD Tier 07 (P2P/Scene)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-bd-tier-08-(mini-encodes).json
+++ b/docs/json/sonarr/cf/anime/anime-bd-tier-08-(mini-encodes).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "89321fab2db8607b1b36e939e6967325",
+  "trash_id": "c81bbfb47fed3d5a3ad027d077f889de",
   "trash_score": "700",
   "name": "Anime BD Tier 08 (Mini Encodes)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-dual-audio.json
+++ b/docs/json/sonarr/cf/anime/anime-dual-audio.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "c2442b96760cdee21d5ca5eebd0a1e0f",
+  "trash_id": "418f50b10f1907201b6cfdf881f467b7",
   "name": "Anime Dual Audio",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/sonarr/cf/anime/anime-dubs-only.json
+++ b/docs/json/sonarr/cf/anime/anime-dubs-only.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "eb715b06bf410aeb7db1f252c48a1b36",
+  "trash_id": "88bb25ff3bbdfab98ea373bf055ea16f",
   "trash_score": "-10000",
   "name": "Anime Dubs Only",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime/anime-lq-groups.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "a40512b6276fa95fe5a00dd6c0d524ed",
+  "trash_id": "e3515e519f3b1360cbfc17651944354c",
   "trash_score": "-10000",
   "name": "Anime LQ Groups",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-raws.json
+++ b/docs/json/sonarr/cf/anime/anime-raws.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "a3003269ea90977932fc87e19485218b",
+  "trash_id": "b4a1b3d705159cdca36d71e57ca86871",
   "trash_score": "-10000",
   "name": "Anime Raws",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-v0.json
+++ b/docs/json/sonarr/cf/anime/anime-v0.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "ce16017747109e4c7f8705b9bd65a34a",
+  "trash_id": "b3c7aa43122c19c125275152e3c59b7b",
   "trash_score": "-51",
   "name": "Anime v0",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-v1.json
+++ b/docs/json/sonarr/cf/anime/anime-v1.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "943da7288709b4e3f3de4d5e47f6c55a",
+  "trash_id": "08d0a845cf9ee23d1f2d59e65ebd3122",
   "trash_score": "1",
   "name": "Anime v1",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-v2.json
+++ b/docs/json/sonarr/cf/anime/anime-v2.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "1be538354e3def87ae598e993e8ebc25",
+  "trash_id": "75657bad303f29fef25c21d8f723a979",
   "trash_score": "2",
   "name": "Anime v2",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-v3.json
+++ b/docs/json/sonarr/cf/anime/anime-v3.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "2ec34bb2064858682be4b10c79919ae3",
+  "trash_id": "8af16305d03cda53b1886d8e02f6cd63",
   "trash_score": "3",
   "name": "Anime v3",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-v4.json
+++ b/docs/json/sonarr/cf/anime/anime-v4.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "8a395f191de3b97088e821142b5dfff1",
+  "trash_id": "9aa96fdee93f2018414d60ec15d1b937",
   "trash_score": "4",
   "name": "Anime v4",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-vrv.json
+++ b/docs/json/sonarr/cf/anime/anime-vrv.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "4354c63d0edc65a92fe2c319f4deac25",
+  "trash_id": "88cc8f4e89efc2da740e115b3cd054ab",
   "trash_score": "10",
   "name": "Anime VRV",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-01-(muxers).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-01-(muxers).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "c8e97b9c9869ba8c9ab8de72878465e1",
+  "trash_id": "e0014372773c8f0e1bef8824f00c7dc4",
   "trash_score": "600",
   "name": "Anime Web Tier 01 (Muxers)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-02-(top-fansubs).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-02-(top-fansubs).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "45e75cdb59950aa55cd451c9347655f4",
+  "trash_id": "19180499de5ef2b84b6ec59aae444696",
   "trash_score": "500",
   "name": "Anime Web Tier 02 (Top FanSubs)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-03-(subsplease).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-03-(subsplease).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "6a4de57c8446e58567460018131261a5",
+  "trash_id": "b5a83ef7296f3c5358236e3452ed1d97",
   "trash_score": "400",
   "name": "Anime Web Tier 03 (SubsPlease)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-04-(official-subs).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-04-(official-subs).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "c045082ac5f40658c5c2fdc11d5e5aa8",
+  "trash_id": "4fd5528a3a8024e6b49f9c67053ea5f3",
   "trash_score": "300",
   "name": "Anime Web Tier 04 (Official Subs)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-05-(fansubs).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-05-(fansubs).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "dd823c2d97c06e0cdae76ee5babdb4ef",
+  "trash_id": "29c2a13d091144f63307e4a8ce963a39",
   "trash_score": "200",
   "name": "Anime Web Tier 05 (FanSubs)",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/sonarr/cf/anime/anime-web-tier-06-(fansubs).json
+++ b/docs/json/sonarr/cf/anime/anime-web-tier-06-(fansubs).json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "f9701b6dbf9fe2403c11f429cebf9645",
+  "trash_id": "dc262f88d74c651b12e9d90b39f6c753",
   "trash_score": "100",
   "name": "Anime Web Tier 06 (FanSubs)",
   "includeCustomFormatWhenRenaming": false,


### PR DESCRIPTION
Updated hash codes for Sonarr CFs. Added Radarr CFs and corrected for source differences.
Currently put them into there own folder and not merged with movies due to an overlap with existing anime files