### PR TITLE
Fixed: `DTS-X` and `DTS-HD MA` recognition

### DIFF
--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -54,7 +54,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -54,7 +54,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dts[ .-]?(ma\\b|hd[ .-]?ma\\b|hd)(?!china|r|maniacs)"
+        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "dts[-. ]?x(?!\\d)"
+        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -9,7 +9,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[ .-]?(ma\\b|hd[ .-]?ma\\b|hd)(?!china|r|maniacs)"
+              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
           }
       },
       {
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -54,7 +54,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -54,7 +54,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "dts[ .-]?(ma\\b|hd[ .-]?ma\\b|hd)(?!china|r|maniacs)"
+        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
       }
     },
     {
@@ -55,7 +55,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "dts[-. ]?x(?!\\d)"
+        "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -9,7 +9,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[ .-]?(ma\\b|hd[ .-]?ma\\b|hd)(?!china|r|maniacs)"
+              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
           }
       },
       {
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "dts[-. ]?x(?!\\d)"
+              "value": "\\b(dts[-_. ]?x)\\b(?!\\d)"
           }
       },
       {


### PR DESCRIPTION
# Pull request

**Purpose**
Fix an issue with the recognition of DTS-HD MA when the file was named DTS-XLL

**Approach**
Adjusted the regex to no longer recognize DTS-XLL as DTS-X but rather DTS-HD MA

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Corrected regex for DTS-X: https://regex101.com/r/kYi5Ua/1
- [x] Corrected regex for DTS-HD MA: https://regex101.com/r/zy2sbh/1

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
