### PR TITLE
Fixed: `DTS-HD MA` recognition

### DIFF
--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
+        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|hd|xll))\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
+              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|hd|xll))\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
+        "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|hd|xll))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|xll))\\b"
+              "value": "\\b(dts[-_. ]?(ma|hd[-_. ]?ma|hd|xll))\\b"
           }
       },
       {


### PR DESCRIPTION

# Pull request

**Purpose**
Fixed the recognition of `DTS-HD MA` for both the Radarr and Sonarr CFs that use the regex.

**Approach**
Added `hd` to the regex to cover for wrongly named `DTS-HD MA` files

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Fix regex for `DTS-HD MA`: https://regex101.com/r/zy2sbh/2

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
