### PR TITLE
Fixed: `E-AC3` detection again

### DIFF
--- a/docs/json/radarr/cf/aac.json
+++ b/docs/json/radarr/cf/aac.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/atmos-undefined.json
+++ b/docs/json/radarr/cf/atmos-undefined.json
@@ -10,7 +10,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dd.json
+++ b/docs/json/radarr/cf/dd.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/ddplus-atmos.json
+++ b/docs/json/radarr/cf/ddplus-atmos.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -9,7 +9,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+](?!A)|e[-_. ]?ac3"
+              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-hra.json
+++ b/docs/json/radarr/cf/dts-hd-hra.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dts-x.json
+++ b/docs/json/radarr/cf/dts-x.json
@@ -36,7 +36,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/dts.json
+++ b/docs/json/radarr/cf/dts.json
@@ -36,7 +36,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/radarr/cf/flac.json
+++ b/docs/json/radarr/cf/flac.json
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       }
   ]

--- a/docs/json/radarr/cf/pcm.json
+++ b/docs/json/radarr/cf/pcm.json
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       }
   ]

--- a/docs/json/radarr/cf/truehd-atmos.json
+++ b/docs/json/radarr/cf/truehd-atmos.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/truehd.json
+++ b/docs/json/radarr/cf/truehd.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/aac.json
+++ b/docs/json/sonarr/cf/aac.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/atmos-undefined.json
+++ b/docs/json/sonarr/cf/atmos-undefined.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dd.json
+++ b/docs/json/sonarr/cf/dd.json
@@ -18,7 +18,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/ddplus-atmos.json
+++ b/docs/json/sonarr/cf/ddplus-atmos.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -9,7 +9,7 @@
           "negate": false,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+](?!A)|e[-_. ]?ac3"
+              "value": "\\bDD[P+](?!A)|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-es.json
+++ b/docs/json/sonarr/cf/dts-es.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-hra.json
+++ b/docs/json/sonarr/cf/dts-hd-hra.json
@@ -27,7 +27,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dts-x.json
+++ b/docs/json/sonarr/cf/dts-x.json
@@ -36,7 +36,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/dts.json
+++ b/docs/json/sonarr/cf/dts.json
@@ -36,7 +36,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       },
       {

--- a/docs/json/sonarr/cf/flac.json
+++ b/docs/json/sonarr/cf/flac.json
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       }
   ]

--- a/docs/json/sonarr/cf/pcm.json
+++ b/docs/json/sonarr/cf/pcm.json
@@ -63,7 +63,7 @@
           "negate": true,
           "required": true,
           "fields": {
-              "value": "[^-]DD[P+]|e[-_. ]?ac3"
+              "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
           }
       }
   ]

--- a/docs/json/sonarr/cf/truehd-atmos.json
+++ b/docs/json/sonarr/cf/truehd-atmos.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/truehd.json
+++ b/docs/json/sonarr/cf/truehd.json
@@ -28,7 +28,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "[^-]DD[P+]|e[-_. ]?ac3"
+        "value": "\\bDD[P+]|\\b(e[-_. ]?ac3)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
Fix the `E-AC3` detection again.

**Approach**
Add word boundaries to the `Dolby Digital Plus` conditions.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Add word boundaries to the regex for `Dolby Digital Plus` https://regex101.com/r/YHN9yA/1
- [x] Look at the `Basic Dolby Digital` condition again.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
