### PR TITLE
Change hotio plex docker profile directory

### DIFF
--- a/docs/Plex/profiles/index.md
+++ b/docs/Plex/profiles/index.md
@@ -13,7 +13,7 @@ To make use of the profiles you need to add it in your your plex folder
 
 Example paths:
 
-* Hotio's container: `/appdata/plex/Profiles`
+* Hotio's container: `/app/usr/lib/plexmediaserver/Resources/Profiles`
 * LSIO container: `/appdata/plex/database/Library/Application Support/Plex Media Server/Profiles` or `/appdata/plex/Library/Application Support/Plex Media Server/Profiles`
 
 ## Profiles


### PR DESCRIPTION
It's no longer at /appdata/plex/Profiles

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
