### PR TITLE
DD+ Negation Fix

### DIFF
--- a/docs/json/radarr/cf/ddplus.json
+++ b/docs/json/radarr/cf/ddplus.json
@@ -31,15 +31,6 @@
           }
       },
       {
-          "name": "Not Basic Dolby Digital",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
-          }
-      },
-      {
           "name": "Not FLAC",
           "implementation": "ReleaseTitleSpecification",
           "negate": true,

--- a/docs/json/sonarr/cf/ddplus.json
+++ b/docs/json/sonarr/cf/ddplus.json
@@ -31,15 +31,6 @@
           }
       },
       {
-          "name": "Not Basic Dolby Digital",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "\\bDD[^a-z+]|(?<!e)ac3"
-          }
-      },
-      {
           "name": "Not FLAC",
           "implementation": "ReleaseTitleSpecification",
           "negate": true,


### PR DESCRIPTION
# Pull request

**Purpose**
Remove `Basic Dolby Digital` negation from `DD+` CFs

**Approach**
If a release is improperly tagged as DD or DD+ but the file is in fact the opposite, no CF is applied. Removing this negation allows the correct CF to be applied.

**Open Questions and Pre-Merge TODOs**
- [ ] TRaSH love me

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
