### PR TITLE
[Starr] CF [x265 (no HDR/DV)] include HDR10(+|Plus)

### DIFF
--- a/docs/json/radarr/cf/x265-no-hdrdv.json
+++ b/docs/json/radarr/cf/x265-no-hdrdv.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "839bea857ed2c0a8e084f3cbdbd65ecb",
   "trash_score": "-10000",
+  "trash_regex": "https://regex101.com/r/yFwxoN/3",
   "name": "x265 (no HDR/DV)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -19,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision|hdr)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]?vision|hdr(10|10plus)?)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/x265-no-hdrdv.json
+++ b/docs/json/sonarr/cf/x265-no-hdrdv.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "9b64dff695c2115facf1b6ea59c9bd07",
   "trash_score": "-10000",
+  "trash_regex": "https://regex101.com/r/yFwxoN/3",
   "name": "x265 (no HDR/DV)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -19,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision|hdr)\\b"
+        "value": "\\b(dv|dovi|dolby[ .]?vision|hdr(10|10plus)?)\\b"
       }
     },
     {


### PR DESCRIPTION
Added: recognizing HDR10(+|Plus)
Added: regex Case

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
