### PR TITLE
[Sonarr] Change CF HMAX hash + fix

### DIFF
--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "17e889ce13117940092308f48b48b45b",
+  "trash_id": "a880d6abc21e7c16884f3ae393f84179",
   "trash_score": "90",
   "name": "HMAX",
   "includeCustomFormatWhenRenaming": true,
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(hmax|hbmo|hbo max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     }
   ]


### PR DESCRIPTION
Changed: CF `HMAX` hash because it was identical with CF `HLG`
Fixed: typo in redex

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
