### PR TITLE
[Backend] consistent naming across CF

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -18,7 +18,7 @@ I also made 3 guides related to this one.
 
     I also suggest to change the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repack-proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repackproper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 
@@ -64,7 +64,7 @@ I also made 3 guides related to this one.
 
 | Misc                                  | Optional                            | &nbsp; | &nbsp; |
 | ------------------------------------- | ----------------------------------- | ------ | ------ |
-| [Repack/Proper](#repack-proper)       | [EVO (no WEBDL)](#evo-no-webdl)     | &nbsp; | &nbsp; |
+| [Repack/Proper](#repackproper)        | [EVO (no WEBDL)](#evo-no-webdl)     | &nbsp; | &nbsp; |
 | [Repack2](#repack2)                   | [No-RlsGroup](#no-rlsgroup)         | &nbsp; | &nbsp; |
 | [Multi](#multi)                       | [Obfuscated](#obfuscated)           | &nbsp; | &nbsp; |
 | [x264](#x264)                         | [Retags](#retags)                   | &nbsp; | &nbsp; |
@@ -1066,7 +1066,7 @@ I also made 3 guides related to this one.
 
 ------
 
-### Repack Proper
+### Repack/Proper
 
 ??? example "JSON - [CLICK TO EXPAND]"
 

--- a/docs/Radarr/Radarr-setup-custom-formats.md
+++ b/docs/Radarr/Radarr-setup-custom-formats.md
@@ -251,7 +251,7 @@ Use the following main settings in your profile.
 
     I also suggest to change the Propers and Repacks settings in Radarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repack-proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -16,7 +16,7 @@ I also made 3 guides related to this one.
 
     I also suggest to change the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repack-proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](#repackproper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 
@@ -64,16 +64,16 @@ I also made 3 guides related to this one.
 
 ------
 
-| Misc                            | Optional                            | &nbsp; | &nbsp; |
-| ------------------------------- | ----------------------------------- | ------ | ------ |
-| [FreeLeech](#freeleech)         | [Season Packs](#season-pack)        | &nbsp; | &nbsp; |
-| [MPEG2](#mpeg2)                 | [Scene](#scene)                     | &nbsp; | &nbsp; |
-| [Multi](#multi)                 | [No-RlsGroup](#no-rlsgroup)         | &nbsp; | &nbsp; |
-| [Repack/Proper](#repack-proper) | [Obfuscated](#obfuscated)           | &nbsp; | &nbsp; |
-| [Repack v2](#repack-v2)         | [Retags](#retags)                   | &nbsp; | &nbsp; |
-| [Repack v3](#repack-v3)         | [Bad Dual Groups](#bad-dual-groups) | &nbsp; | &nbsp; |
-| [x264](#x264)                   |                                     | &nbsp; | &nbsp; |
-| [x265](#x265)                   |                                     | &nbsp; | &nbsp; |
+| Misc                           | Optional                            | &nbsp; | &nbsp; |
+| ------------------------------ | ----------------------------------- | ------ | ------ |
+| [FreeLeech](#freeleech)        | [Season Packs](#season-pack)        | &nbsp; | &nbsp; |
+| [MPEG2](#mpeg2)                | [Scene](#scene)                     | &nbsp; | &nbsp; |
+| [Multi](#multi)                | [No-RlsGroup](#no-rlsgroup)         | &nbsp; | &nbsp; |
+| [Repack/Proper](#repackproper) | [Obfuscated](#obfuscated)           | &nbsp; | &nbsp; |
+| [Repack v2](#repack-v2)        | [Retags](#retags)                   | &nbsp; | &nbsp; |
+| [Repack v3](#repack-v3)        | [Bad Dual Groups](#bad-dual-groups) | &nbsp; | &nbsp; |
+| [x264](#x264)                  |                                     | &nbsp; | &nbsp; |
+| [x265](#x265)                  |                                     | &nbsp; | &nbsp; |
 
 ------
 
@@ -81,7 +81,7 @@ I also made 3 guides related to this one.
 | --------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------- |
 | [Anime BD Tier 01 (Top SeaDex Muxers)](#anime-bd-tier-01-top-seadex-muxers) | [Anime Web Tier 01 (Muxers)](#anime-web-tier-01-muxers)               | [Uncensored](#uncensored)             |
 | [Anime BD Tier 02 (SeaDex Muxers)](#anime-bd-tier-02-seadex-muxers)         | [Anime Web Tier 02 (Top FanSubs)](#anime-web-tier-02-top-fansubs)     | [v0](#v0)                             |
-| [Anime BD Tier 03 (SeaDex Muxers)](#anime-bd-tier-03-seadex-muxers)         | [Anime Web Tier 03 (SubsPlease)](#anime-web-tier-03-subsplease)       | [v1](#v1)                              |
+| [Anime BD Tier 03 (SeaDex Muxers)](#anime-bd-tier-03-seadex-muxers)         | [Anime Web Tier 03 (SubsPlease)](#anime-web-tier-03-subsplease)       | [v1](#v1)                             |
 | [Anime BD Tier 04 (SeaDex Muxers)](#anime-bd-tier-04-seadex-muxers)         | [Anime Web Tier 04 (Official Subs)](#anime-web-tier-04-official-subs) | [v2](#v2)                             |
 | [Anime BD Tier 05 (Remuxes)](#anime-bd-tier-05-remuxes)                     | [Anime Web Tier 05 (FanSubs)](#anime-web-tier-05-fansubs)             | [v3](#v3)                             |
 | [Anime BD Tier 06 (FanSubs)](#anime-bd-tier-06-fansubs)                     | [Anime Web Tier 06 (FanSubs)](#anime-web-tier-06-fansubs)             | [v4](#v4)                             |
@@ -869,7 +869,7 @@ I also made 3 guides related to this one.
 
 ------
 
-### Repack Proper
+### Repack/Proper
 
 ??? example "JSON - [CLICK TO EXPAND]"
 

--- a/docs/Sonarr/sonarr-setup-custom-formats.md
+++ b/docs/Sonarr/sonarr-setup-custom-formats.md
@@ -179,7 +179,7 @@ Use the following main settings in your profile.
 
     I also suggest to change the Propers and Repacks settings in Sonarr
 
-    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repack-proper) Custom Format.
+    `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
 
     ![!cf-mm-propers-repacks-disable](images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/cf/radarr-misc.md
+++ b/includes/cf/radarr-misc.md
@@ -1,14 +1,14 @@
 ??? summary "Misc - [CLICK TO EXPAND]"
     | Custom Format                                                                                       | Score                                        | Trash ID                                  |
     | --------------------------------------------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------- |
-    | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack-proper) | {{ radarr['cf']['repack-proper']['trash_score'] }} | {{ radarr['cf']['repack-proper']['trash_id'] }} |
+    | [{{ radarr['cf']['repack-proper']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repackproper) | {{ radarr['cf']['repack-proper']['trash_score'] }} | {{ radarr['cf']['repack-proper']['trash_id'] }} |
     | [{{ radarr['cf']['repack2']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#repack2)             | {{ radarr['cf']['repack2']['trash_score'] }}       | {{ radarr['cf']['repack2']['trash_id'] }}       |
 
     ??? tip "Proper and Repacks - [CLICK TO EXPAND]"
 
         I also suggest to change the Propers and Repacks settings in Radarr
 
-        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repack-proper) Custom Format.
+        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Radarr/Radarr-collection-of-custom-formats/#repackproper) Custom Format.
 
         ![!cf-mm-propers-repacks-disable](/Radarr/images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/cf/sonarr-misc.md
+++ b/includes/cf/sonarr-misc.md
@@ -1,7 +1,7 @@
 ??? summary "Misc - [CLICK TO EXPAND]"
     | Custom Format                                                                                             | Score                                              | Trash ID                                        |
     | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------- |
-    | [{{ sonarr['cf']['repack-proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-proper) | {{ sonarr['cf']['repack-proper']['trash_score'] }} | {{ sonarr['cf']['repack-proper']['trash_id'] }} |
+    | [{{ sonarr['cf']['repack-proper']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) | {{ sonarr['cf']['repack-proper']['trash_score'] }} | {{ sonarr['cf']['repack-proper']['trash_id'] }} |
     | [{{ sonarr['cf']['repack-v2']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v2)             | {{ sonarr['cf']['repack-v2']['trash_score'] }}       | {{ sonarr['cf']['repack-v2']['trash_id'] }}       |
     | [{{ sonarr['cf']['repack-v3']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#repack-v3)             | {{ sonarr['cf']['repack-v3']['trash_score'] }}       | {{ sonarr['cf']['repack-v3']['trash_id'] }}       |
 
@@ -9,7 +9,7 @@
 
         I also suggest to change the Propers and Repacks settings in Sonarr
 
-        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repack-proper) Custom Format.
+        `Media Management` => `File Management` to `Do Not Prefer` and use the [Repack/Proper](/Sonarr/sonarr-collection-of-custom-formats/#repackproper) Custom Format.
 
         ![!cf-mm-propers-repacks-disable](/Sonarr/images/cf-mm-propers-repacks-disable.png)
 

--- a/includes/merge-quality/radarr-current-logic.md
+++ b/includes/merge-quality/radarr-current-logic.md
@@ -20,4 +20,4 @@
     !!! attention ""
         REPACKS and PROPERs are v2 of Qualities and thus rank above a non-repack of the same quality.
 
-         `Settings` => `Media Management` => `File Management` => `Proper & Repacks` Change to `Do Not Prefer` and use the [Repack/Proper Custom Format](/Radarr/Radarr-collection-of-custom-formats/#repack-proper){:target="_blank" rel="noopener noreferrer"}
+         `Settings` => `Media Management` => `File Management` => `Proper & Repacks` Change to `Do Not Prefer` and use the [Repack/Proper Custom Format](/Radarr/Radarr-collection-of-custom-formats/#repackproper){:target="_blank" rel="noopener noreferrer"}


### PR DESCRIPTION
- Changed: link repack-proper to repackproper to be consistent with `/` being removed by markdown
