### PR TITLE
Radarr CF `[Flights (no IMAX)`

### DIFF
--- a/docs/json/radarr/cf/flights-no-imax.json
+++ b/docs/json/radarr/cf/flights-no-imax.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "1d433e1e075704f1a8a1ae3e1c371460",
-  "trash_score": "1850",
+  "trash_score": "0",
   "name": "Flights (no IMAX)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/includes/sqp/1-2-cf-scoring.md
+++ b/includes/sqp/1-2-cf-scoring.md
@@ -10,7 +10,6 @@
     | Custom Format                                                                                                                                    | Score                                                | Trash ID                                          |
     | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------- |
     | [{{ radarr['cf']['hq-remux']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hq-remux)                                                  | {{ radarr['cf']['hq-remux']['trash_score'] }}        | {{ radarr['cf']['hq-remux']['trash_id'] }}        |
-    | [{{ radarr['cf']['flights-no-imax']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/flights-no-imax.json) | {{ radarr['cf']['flights-no-imax']['trash_score'] }} | {{ radarr['cf']['flights-no-imax']['trash_id'] }} |
     | [{{ radarr['cf']['hq-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hq-webdl)                                                  | {{ radarr['cf']['hq-webdl']['trash_score'] }}        | {{ radarr['cf']['hq-webdl']['trash_id'] }}        |
     | [{{ radarr['cf']['hq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hq)                                                              | 0                                                    | {{ radarr['cf']['hq']['trash_id'] }}              |
 


### PR DESCRIPTION
- Lowered Score to `0` because it will be removed upcoming weekend, and it's already added to CF `[HQ-Remux]` and `[Remux Tier 02]`

