### PR TITLE
Moving Yameii from Anime LQ to Dubs Only for Sonarr CFs

### DIFF
--- a/docs/json/sonarr/cf/anime-lq-groups.json
+++ b/docs/json/sonarr/cf/anime-lq-groups.json
@@ -1166,15 +1166,6 @@
       }
     },
     {
-      "name": "Yameii",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\[Yameii\\]|-Yameii\\b"
-      }
-    },
-    {
       "name": "youshikibi",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/dubs-only.json
+++ b/docs/json/sonarr/cf/dubs-only.json
@@ -57,6 +57,15 @@
       "fields": {
         "value": "\\b(torenter69)\\b"
       }
+    },
+    {
+      "name": "Yameii",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yameii\\]|-Yameii\\b"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Moving Yameii from Anime LQ to Dubs Only for Sonarr CFs

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
