### PR TITLE
Revert "build(deps): bump mkdocs-include-markdown-plugin from 3.8.0 to 3.9.0"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ mkdocs-macros-plugin==0.7.0
 mkdocs-material==8.5.4
 mkdocs-minify-plugin==0.5.0
 mkdocs-redirects==1.2.0
-mkdocs-include-markdown-plugin==3.9.0
+mkdocs-include-markdown-plugin==3.8.0
 mkdocs-markdownextradata-plugin==0.2.5


### PR DESCRIPTION
Reverts TRaSH-/Guides#851