### PR TITLE
Fixed: Double IMAX in the file name

### DIFF
--- a/docs/json/radarr/cf/imax.json
+++ b/docs/json/radarr/cf/imax.json
@@ -2,7 +2,7 @@
   "trash_id": "eecf3a857724171f968a66cb5719e152",
   "trash_score": "800",
   "name": "IMAX",
-  "includeCustomFormatWhenRenaming": true,
+  "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
       "name": "IMAX",


### PR DESCRIPTION
# Pull request

**Purpose**
Get rid of the double naming for the IMAX CF.

**Approach**
Remove the CF naming for IMAX to get rid of the double naming.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
