### PR TITLE
DTS-HD MA: Remove Basic DTS negation

### DIFF
--- a/docs/json/radarr/cf/dts-hd-ma.json
+++ b/docs/json/radarr/cf/dts-hd-ma.json
@@ -32,15 +32,6 @@
       }
     },
     {
-      "name": "Not Basic DTS",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "DTS[ .]?[1-9]"
-      }
-    },
-    {
       "name": "Not Basic Dolby Digital ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/dts-hd-ma.json
+++ b/docs/json/sonarr/cf/dts-hd-ma.json
@@ -32,15 +32,6 @@
       }
     },
     {
-      "name": "Not Basic DTS",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "DTS[ .]?[1-9]"
-      }
-    },
-    {
       "name": "Not Basic Dolby Digital ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull request

**Purpose**
Similar to #781 

With a release tagged as DTS but detected on import as DTS-HD MA, no CFs will be applied to the file on disk because of the Basic DTS negation. This results in a grab/upgrade loop.

**Approach**
Remove Basic DTS negation. The DTS CF will handle this negation to ensure both are not applied.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Same change for Sonarr

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
