### PR TITLE
Add `PROPJOE` as scene

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -497,7 +497,7 @@ Add this to your `Must not contain (2)`
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ]|-CAKES\b|-GGEZ\b|-GGWP\b|-GLHF\b|-GOSSIP\b|-KOGI\b|-PECULATE\b)).*/i
+/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ]|-CAKES\b|-GGEZ\b|-GGWP\b|-GLHF\b|-GOSSIP\b|-KOGI\b|-PECULATE\b|-PROPJOE\b)).*/i
 
 ```
 

--- a/docs/json/sonarr/rp/optionals.json
+++ b/docs/json/sonarr/rp/optionals.json
@@ -16,7 +16,7 @@
   }, {
     "name": "Ignore so called scene releases",
     "trash_id": "5bc23c3a055a1a5d8bbe4fb49d80e0cb",
-    "term": "/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ]|-CAKES\\b|-GGEZ\\b|-GGWP\\b|-GLHF\\b|-GOSSIP\\b|-KOGI\\b|-PECULATE\\b)).*/i"
+    "term": "/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ]|-CAKES\\b|-GGEZ\\b|-GGWP\\b|-GLHF\\b|-GOSSIP\\b|-KOGI\\b|-PECULATE\\b|-PROPJOE\\b)).*/i"
   }, {
     "name": "Dislike Bad Dual Audio Groups",
     "trash_id": "538bad00ee6f8aced8e0db5218b8484c",


### PR DESCRIPTION
# Pull request

**Purpose**
Lately PROPJOE has released some scene releases, and I found out they only add french subtitles.

**Approach**
adds PROPJOE to regex

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
