### PR TITLE
Radarr - remove dts negate from dts-es

### DIFF
--- a/docs/json/radarr/cf/dts-es.json
+++ b/docs/json/radarr/cf/dts-es.json
@@ -31,15 +31,6 @@
           }
       },
       {
-          "name": "Not Basic DTS",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "DTS[ .]?[1-9]"
-          }
-      },
-      {
           "name": "Not Basic Dolby Digital ",
           "implementation": "ReleaseTitleSpecification",
           "negate": true,


### PR DESCRIPTION
# Pull request

**Purpose**
`Deadpool.2016.1080p.BluRay.DTS-ES.x264-TayTO` => `Deadpool (2016) {imdb-tt1431045} [Bluray-1080p][DTS 5.1][x264]-TayTO.mkv` causes a loop. As it is both DTS (disk) and DTS-ES (scenename) and yet cannot be DTS (blocked by not DTS-ES) nor can it be DTS-ES (blocked by DTS)

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
