### PR TITLE
Added: `HONE` and `CRFW` to `WEB Tier 01`

### DIFF
--- a/docs/json/sonarr/cf/web-tier-01.json
+++ b/docs/json/sonarr/cf/web-tier-01.json
@@ -32,6 +32,15 @@
       }
     },
     {
+      "name": "CRFW",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CRFW)\\b"
+      }
+    },
+    {
       "name": "CtrlHD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,
@@ -47,6 +56,15 @@
       "required": false,
       "fields": {
         "value": "\\b(FLUX)\\b"
+      }
+    },
+    {
+      "name": "HONE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HONE)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
`HONE` and `CRFW` release `DV HDR` hybrids of various shows.

**Approach**
Adding `HONE` and `CRFW` to `WEB Tier 01`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
