### PR TITLE
Plex: cleanup

### DIFF
--- a/docs/Plex/.pages
+++ b/docs/Plex/.pages
@@ -1,4 +1,4 @@
 nav:
     - Home: index.md
-    - Profiles: /Plex/profiles/
     - Tips
+    - Profiles: /Plex/profiles/

--- a/docs/Plex/Tips/.pages
+++ b/docs/Plex/Tips/.pages
@@ -2,7 +2,3 @@ nav:
     - Suggested Plex Media Server Settings: Plex-media-server.md
     - Optimal Plex Client Settings: Optimal-plex-client-settings.md
     - JBOPS 4K Transcode Stopping with Tautulli: 4k-transcoding.md
-
-
-
-

--- a/docs/Plex/Tips/4k-transcoding.md
+++ b/docs/Plex/Tips/4k-transcoding.md
@@ -45,8 +45,8 @@ Condition Logic
 
 ## Arguments
 
-```plaintext
 Under each: Playback Start, Playback Resume, Transcode Decision Change
 
+```plaintext
 --jbop stream --username {username} --sessionId {session_id} --killMessage 'Transcoding streams are not allowed for {video_resolution} streams.'
 ```

--- a/docs/Plex/profiles/index.md
+++ b/docs/Plex/profiles/index.md
@@ -1,9 +1,9 @@
 # Plex Profiles
 
-!!! note ""
-    Here you will find a collection of profiles you can use with Plex.
+!!! info
+    Here you will find a collection of profiles you only should use if Plex has issues direct playing your media on your devices, these profiles could help but results might vary.
 
-    Profiles are used if Plex has issues direct playing your media on your devices, these profiles could help but result.
+!!! danger "The profiles aren't tested on the Shield 2019 or newer Chromecast models :warning:"
 
 ## How to
 
@@ -18,7 +18,7 @@ Example paths:
 
 ## Profiles
 
-!!! attention ""
+!!! tip
     If you got some to share, pls make a PR so we can collect them at one place
 
 ### Android Shield


### PR DESCRIPTION
- Moved: Tips above profiles.
- Fixed: copy/paste option.
- Fixed: Formatting for profiles page.
- Added: warning for untested on new Shield/Chromecast models.
