### PR TITLE
[Radarr] Lowered min Quality Size

### DIFF
--- a/docs/json/radarr/quality-size/movie.json
+++ b/docs/json/radarr/quality-size/movie.json
@@ -10,13 +10,13 @@
         },
         {
             "quality": "WEBDL-720p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 399,
             "max": 400
         },
         {
             "quality": "WEBRip-720p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 399,
             "max": 400
         },
@@ -34,13 +34,13 @@
         },
         {
             "quality": "WEBDL-1080p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 399,
             "max": 400
         },
         {
             "quality": "WEBRip-1080p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 399,
             "max": 400
         },
@@ -64,13 +64,13 @@
         },
         {
             "quality": "WEBDL-2160p",
-            "min": 50.8,
+            "min": 34.5,
             "preferred": 399,
             "max": 400
         },
         {
             "quality": "WEBRip-2160p",
-            "min": 50.8,
+            "min": 34.5,
             "preferred": 399,
             "max": 400
         },

--- a/docs/json/radarr/quality-size/sqp-streaming.json
+++ b/docs/json/radarr/quality-size/sqp-streaming.json
@@ -4,25 +4,25 @@
     "qualities": [
         {
             "quality": "WEBDL-720p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 84.7,
             "max": 85.7
         },
         {
             "quality": "WEBRip-720p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 84.7,
             "max": 85.7
         },
         {
             "quality": "WEBDL-1080p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 84.7,
             "max": 85.7
         },
         {
             "quality": "WEBRip-1080p",
-            "min": 17.1,
+            "min": 12.5,
             "preferred": 84.7,
             "max": 85.7
         },

--- a/docs/json/radarr/quality-size/sqp-uhd.json
+++ b/docs/json/radarr/quality-size/sqp-uhd.json
@@ -5,13 +5,13 @@
   "qualities": [
       {
           "quality": "WEBDL-1080p",
-          "min": 17.1,
+          "min": 12.5,
           "preferred": 399,
           "max": 400
       },
       {
           "quality": "WEBRip-1080p",
-          "min": 17.1,
+          "min": 12.5,
           "preferred": 399,
           "max": 400
       },
@@ -29,13 +29,13 @@
       },
       {
           "quality": "WEBDL-2160p",
-          "min": 50.8,
+          "min": 34.5,
           "preferred": 399,
           "max": 400
       },
       {
           "quality": "WEBRip-2160p",
-          "min": 50.8,
+          "min": 34.5,
           "preferred": 399,
           "max": 400
       },


### PR DESCRIPTION
- Changed: Min. Quality Size for WEBDL because of the smaller NF releases.

