### PR TITLE
[Guide] Maintenance Release 20221107

### DIFF
--- a/docs/json/radarr/cf/special-edition.json
+++ b/docs/json/radarr/cf/special-edition.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "957d0f44b592285f26449575e8b1167e",
-  "trash_score": "25",
+  "trash_score": "125",
   "trash_regex": "https://regex101.com/r/ZUo0H1/1",
   "name": "Special Edition",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/quality-size/sqp-streaming.json
+++ b/docs/json/radarr/quality-size/sqp-streaming.json
@@ -35,8 +35,8 @@
         {
             "quality": "Bluray-1080p",
             "min": 33.8,
-            "preferred": 135.9,
-            "max": 136.9
+            "preferred": 153,
+            "max": 154
         }
     ]
 }

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,14 @@
+# 2022-11-07 23:00
+**[SQP-1]**
+- Removed: un-needed optional. #962
+- Changed: max quality size. #962
+
+**[Radarr]**
+- Updated: CF `[Special Edition]` Score from `25` to `125`. #962
+
+**[SQP-2-5]**
+- Add: correct link for CF `[SDR]`. #962
+
 # 2022-11-04 23:30
 **[Radarr Guide]**
 - Add: Main Flowchart to `How to setup Custom Formats` guide. #955

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -59,7 +59,7 @@
 
 {! include-markdown "../../includes/cf/radarr-unwanted.md" !}
 
-{! include-markdown "../../includes/cf/hd-radarr-optional.md" !}
+{! include-markdown "../../includes/sqp/hd-radarr-optional.md" !}
 
 {! include-markdown "../../includes/sqp/hd-radarr-resolution.md" !}
 

--- a/includes/sqp/1-cf-scoring.md
+++ b/includes/sqp/1-cf-scoring.md
@@ -59,7 +59,7 @@
 
 {! include-markdown "../../includes/cf/radarr-unwanted.md" !}
 
-{! include-markdown "../../includes/cf/radarr-optional.md" !}
+{! include-markdown "../../includes/cf/hd-radarr-optional.md" !}
 
 {! include-markdown "../../includes/sqp/hd-radarr-resolution.md" !}
 

--- a/includes/sqp/hd-radarr-optional.md
+++ b/includes/sqp/hd-radarr-optional.md
@@ -1,0 +1,21 @@
+??? summary "Optional - [CLICK TO EXPAND]"
+    | Custom Format                                                                                                 | Score                                                | Trash ID                                          |
+    | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------- |
+    | [{{ radarr['cf']['bad-dual-groups']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bad-dual-groups) | {{ radarr['cf']['bad-dual-groups']['trash_score'] }} | {{ radarr['cf']['bad-dual-groups']['trash_id'] }} |
+    | [{{ radarr['cf']['evo-no-webdl']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#evo-no-webdl)       | {{ radarr['cf']['evo-no-webdl']['trash_score'] }}    | {{ radarr['cf']['evo-no-webdl']['trash_id'] }}    |
+    | [{{ radarr['cf']['no-rlsgroup']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#no-rlsgroup)         | {{ radarr['cf']['no-rlsgroup']['trash_score'] }}     | {{ radarr['cf']['no-rlsgroup']['trash_id'] }}     |
+    | [{{ radarr['cf']['obfuscated']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#obfuscated)           | {{ radarr['cf']['obfuscated']['trash_score'] }}      | {{ radarr['cf']['obfuscated']['trash_id'] }}      |
+    | [{{ radarr['cf']['retags']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#retags)                   | {{ radarr['cf']['retags']['trash_score'] }}          | {{ radarr['cf']['retags']['trash_id'] }}          |
+    | [{{ radarr['cf']['scene']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#scene)                     | {{ radarr['cf']['scene']['trash_score'] }}           | {{ radarr['cf']['scene']['trash_id'] }}           |
+
+    ------
+
+    Breakdown and Why
+
+    - **{{ radarr['cf']['bad-dual-groups']['name'] }}:** [*Optional*] These groups take the original release, then they add their own preferred language (ex. Portuguese) as the main audio track (AAC 2.0), What results after renaming and FFprobe that the media file will be recognized as Portuguese AAC audio. It's a common rule that you add the best audio as first.
+    Also they often even rename the release name in to Portuguese.
+    - **{{ radarr['cf']['evo-no-webdl']['name'] }}:** This group is often banned for the low quality Blu-ray releases, but their WEB-DL are okay.
+    - **{{ radarr['cf']['no-rlsgroup']['name'] }}:** [*Optional*] Some indexers strip out the release group what could result in LQ groups getting a higher score. For example a lot of EVO releases end up stripping the group name, so they appear as "upgrades", and they end up getting a decent score if other things match.
+    - **{{ radarr['cf']['obfuscated']['name'] }}:** [*Optional*] (use these only if you dislike renamed releases)
+    - **{{ radarr['cf']['retags']['name'] }}:** [*Optional*] (use these only if you dislike retagged releases)
+    - **{{ radarr['cf']['scene']['name'] }}:** [*Optional*] (use these only if you dislike scene releases)

--- a/includes/sqp/uhd-radarr-unwanted.md
+++ b/includes/sqp/uhd-radarr-unwanted.md
@@ -1,10 +1,10 @@
 ??? summary "Unwanted - [CLICK TO EXPAND]"
-    | Custom Format                                                                                 | Score                                        | Trash ID                                  |
-    | --------------------------------------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------- |
-    | [{{ radarr['cf']['br-disk']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#br-disk) | {{ radarr['cf']['br-disk']['trash_score'] }} | {{ radarr['cf']['br-disk']['trash_id'] }} |
-    | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)           | {{ radarr['cf']['lq']['trash_score'] }}      | {{ radarr['cf']['lq']['trash_id'] }}      |
-    | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)           | {{ radarr['cf']['3d']['trash_score'] }}      | {{ radarr['cf']['3d']['trash_id'] }}      |
-    | [{{ radarr['cf']['sdr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#sdr)         | {{ radarr['cf']['sdr']['trash_score'] }}     | {{ radarr['cf']['sdr']['trash_id'] }}     |
+    | Custom Format                                                                                                            | Score                                        | Trash ID                                  |
+    | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | ----------------------------------------- |
+    | [{{ radarr['cf']['br-disk']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#br-disk)                            | {{ radarr['cf']['br-disk']['trash_score'] }} | {{ radarr['cf']['br-disk']['trash_id'] }} |
+    | [{{ radarr['cf']['lq']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#lq)                                      | {{ radarr['cf']['lq']['trash_score'] }}      | {{ radarr['cf']['lq']['trash_id'] }}      |
+    | [{{ radarr['cf']['3d']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#3d)                                      | {{ radarr['cf']['3d']['trash_score'] }}      | {{ radarr['cf']['3d']['trash_id'] }}      |
+    | [{{ radarr['cf']['sdr']['name'] }}](https://raw.githubusercontent.com/TRaSH-/Guides/master/docs/json/radarr/cf/sdr.json) | {{ radarr['cf']['sdr']['trash_score'] }}     | {{ radarr['cf']['sdr']['trash_id'] }}     |
 
     ------
     Breakdown and Why


### PR DESCRIPTION
**[SQP-1]**
- Removed: un-needed optional.

**[Radarr]**
- Updated: CF `[Special Edition]` Score from `25` to `125`.

**[SQP-2-5]**
- Add: correct link for CF `[SDR]`.
