### PR TITLE
add Lilith-Raws to anime-raws.json

### DIFF
--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -120,6 +120,15 @@
       "fields": {
         "value": "\\b(Seicher)\\b"
       }
+    },
+    {
+      "name": "Lilith",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Lilith[ ._-]?(Raws)"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -50,6 +50,15 @@
       }
     },
     {
+      "name": "Lilith-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Lilith[ ._-]?(Raws)"
+      }
+    },
+    {
       "name": "LowPower-raws",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
@@ -119,15 +128,6 @@
       "required": false,
       "fields": {
         "value": "\\b(Seicher)\\b"
-      }
-    },
-    {
-      "name": "Lilith",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "Lilith[ ._-]?(Raws)"
       }
     }
   ]


### PR DESCRIPTION
# Pull request

**Purpose**
add Lilith-Raws to anime-raws.json

**Approach**
This change is to add an additional raws group to the anime-raws.json to avoid pulling an additional group releasing raws. 
https://regex101.com/r/k2Xmal/1

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
