### PR TITLE
Sonarr maintenance release

### DIFF
--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -56,11 +56,13 @@ I also made 3 guides related to this one.
 |                       |                       |                             | [HBO Max](#hmax)    |
 |                       |                       |                             | [HBO](#hbo)         |
 |                       |                       |                             | [Hulu](#hulu)       |
+|                       |                       |                             | [NLZiet](#nlz)      |
 |                       |                       |                             | [Netflix](#nf)      |
 |                       |                       |                             | [Paramount+](#pmtp) |
 |                       |                       |                             | [Peacock TV](#pcok) |
 |                       |                       |                             | [Quibi](#qibi)      |
 |                       |                       |                             | [SHOWTIME](#sho)    |
+|                       |                       |                             | [Videoland](#vdl)   |
 |                       |                       |                             | [YouTube Red](#red) |
 |                       |                       |                             | [iTunes](#it)       |
 
@@ -1303,6 +1305,24 @@ I also made 3 guides related to this one.
 
 ------
 
+### NLZ
+
+<sub>NLZiet</sub>
+
+??? faq "NLZiet - [CLICK TO EXPAND]"
+
+    NLZIET is the online service of Dutch broadcasters that provides non-stop tv, commercial-free. The streaming service brings the best of all channels straight to your preferred device and lets you see your favorite tv content in high quality on all available platforms; anytime and anywhere.
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/nlz.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
 ### NF
 
 <sub>Netflix</sub>
@@ -1387,6 +1407,24 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/sho.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### VDL
+
+<sub>Videoland</sub>
+
+??? faq "Videoland - [CLICK TO EXPAND]"
+
+    Videoland is a Dutch OTT online service provider owned by RTL Nederland. Originally it was a retail chain of video rental stores. Its main competitor is Netflix.
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/vdl.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/sonarr/cf/nlz.json
+++ b/docs/json/sonarr/cf/nlz.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "b2b980877494b560443631eb1f473867",
+  "trash_score": "75",
+  "name": "NLZ",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "NLZiet",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(nlz|NLZiet)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/vdl.json
+++ b/docs/json/sonarr/cf/vdl.json
@@ -1,0 +1,17 @@
+{
+  "trash_id": "5d2317d99af813b6529c7ebf01c83533",
+  "trash_score": "75",
+  "name": "VDL",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Videoland",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(vdl|Videoland)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/web-tier-03.json
+++ b/docs/json/sonarr/cf/web-tier-03.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "SwAgLaNdEr",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SwAgLaNdEr)\\b"
+      }
+    },
+    {
       "name": "T4H",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/sonarr/rp/lqGroups.json
+++ b/docs/json/sonarr/rp/lqGroups.json
@@ -4,7 +4,7 @@
   "includePreferredWhenRenaming": false,
   "required": [],
   "preferred": [{
-    "score": -100,
+    "score": -10000,
     "terms": [
       "/(-BRiNK|-CHX|-GHOSTS|MeGusta|-NERO|nhanc3|Pahe\\.ph|Pahe\\.in|TBS|-VIDEOHOLE|-worldmkv|-XLF)\\b/i"
     ]

--- a/docs/json/sonarr/rp/optionals.json
+++ b/docs/json/sonarr/rp/optionals.json
@@ -35,21 +35,21 @@
       "term": "/\\bS\\d+\\b(?!E\\d+\\b)/i"
     }]
   }, {
-    "score": 10,
+    "score": 500,
     "terms": [{
       "name": "Prefer HDR",
       "trash_id": "bc7a6383cbe88c3ee2d6396e1aacc0b3",
       "term": "/\\bHDR(\\b|\\d)/i"
     }]
   }, {
-    "score": 100,
+    "score": 1500,
     "terms": [{
       "name": "Prefer Dolby Vision",
       "trash_id": "fa47da3377076d82d07c4e95b3f13d07",
       "term": "/\\b(dv|dovi|dolby[ .]?vision)\\b/i"
     }]
   }, {
-    "score": -25,
+    "score": -10000,
     "terms": [{
       "name": "Dislike retags: rartv, rarbg, eztv, TGx",
       "trash_id": "6f2aefa61342a63387f2a90489e90790",

--- a/docs/json/sonarr/rp/p2pRepackProper.json
+++ b/docs/json/sonarr/rp/p2pRepackProper.json
@@ -4,43 +4,43 @@
   "includePreferredWhenRenaming": false,
   "required": [],
   "preferred": [{
-      "score": 180,
+      "score": 1800,
       "terms": [
         "/(-deflate|-inflate)\\b/i"
       ]
     },
     {
-      "score": 150,
+      "score": 1700,
       "terms": [
-        "/(-ABBIE|-AJP69|-CasStudio|-CtrlHD|-FLUX|-KiNGS|-monkee|NOSiViD|-NTb|-NTG|-QOQ|-RTN|-SIC|T6D|-TOMMY|-ViSUM)\\b/i"
+        "/(-ABBIE|-AJP69|-CasStudio|CRFW|-CtrlHD|-FLUX|\\bHONE|-KiNGS|-monkee|NOSiViD|-NTb|-NTG|-QOQ|-RTN|-SIC|T6D|-TOMMY|-ViSUM)\\b/i"
       ]
     },
     {
-      "score": 125,
+      "score": 1650,
       "terms": [
-        "/(3CTWeB|BLUTONiUM|-BTW|-Chotab|-Cinefeel|-CiT|Coo7|-dB|-DEEP|-END|-ETHiCS|-FC|-Flights|-GNOME|-iJP|-iKA|-iT00NZ|-JETIX|-KHN|-KiMCHI|-LAZY|-MZABI|-NPMS|-NYH|-orbitron|playWEB|PSiG|-ROCCaT|RTFM|-SA89|-SIGMA|-SMURF|-SPiRiT|-TEPES|-TVSmash|-WELP)\\b/i"
+        "/(3CTWeB|BLUTONiUM|-BTW|-Chotab|-Cinefeel|-CiT|Coo7|-dB|-DEEP|-END|-ETHiCS|-FC|-Flights|-GNOME|-iJP|-iKA|-iT00NZ|-JETIX|-KHN|-KiMCHI|-LAZY|-MZABI|-NPMS|-NYH|-orbitron|playWEB|PSiG|-ROCCaT|RTFM|-SA89|-SDCC|-SIGMA|-SMURF|-SPiRiT|-TEPES|-TVSmash|-WELP)\\b/i"
       ]
     },
     {
-      "score": 100,
+      "score": 1600,
       "terms": [
-        "/(-ViSiON)\\b/i"
+        "/(SLiGNOME|T4H|-ViSiON|SwAgLaNdEr)\\b/i"
       ]
     },
     {
-      "score": 12,
+      "score": 13,
       "terms": [
         "/(repack3)/i"
       ]
     },
     {
-      "score": 11,
+      "score": 12,
       "terms": [
         "/(repack2)/i"
       ]
     },
     {
-      "score": 10,
+      "score": 11,
       "terms": [
         "/\\b(repack|proper)\\b/i"
       ]

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -39,7 +39,9 @@
         "/\\b(hbo)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(red)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(it)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(pmtp)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(pmtp)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(vdl)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(nlz)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     }
   ],


### PR DESCRIPTION
**[Sonarr]**

- Added: Videoland + NLZIET streaming services
- Added: RlsGrp `SwAgLaNdEr` This is a group that's on the BTN list and does Dutch TV shows from different Dutch Streaming Services.
- Added: RlsGrp `CRFW`, `SDCC`, `SLiGNOME`, `T4H`.
- Added: RlsGrp `HONE` known for their hybrid 4k releases.
- Updated: Scores to be consistent with Radarr/Sonarr.
- Updated: Scores to be consistent with Radarr/Sonarr.