### PR TITLE
added NanakoRaws and Lilith-Raws to anime-raws

### DIFF
--- a/docs/json/radarr/cf/anime-raws.json
+++ b/docs/json/radarr/cf/anime-raws.json
@@ -50,12 +50,30 @@
       }
     },
     {
+      "name": "Lilith-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Lilith[ ._-]?(Raws)"
+      }
+    },
+    {
       "name": "LowPower-raws",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": false,
       "fields": {
         "value": "LowPower[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "NanakoRaws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Nanako(Raws)"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-raws.json
+++ b/docs/json/sonarr/cf/anime-raws.json
@@ -68,6 +68,15 @@
       }
     },
     {
+      "name": "NanakoRaws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Nanako(Raws)"
+      }
+    },
+    {
       "name": "NC-raws",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
to add NanakoRaws and Lilith-Raws to anime-raws for radarr and to add NanakoRaws to sonarr anime-raws

**Approach**
This will prevent NanakoRaws from being acidentially grabbed
https://regex101.com/r/kEwblA/1

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
