### PR TITLE
Update 2160p CFs (Radarr/Sonarr) and SDR CF (Radarr)

### DIFF
--- a/docs/json/radarr/cf/2160p.json
+++ b/docs/json/radarr/cf/2160p.json
@@ -14,30 +14,12 @@
       }
     },
     {
-      "name": "HDR",
+      "name": "HDR Formats",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": false,
+      "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision|DV[ .]HDR10|DV[ .]HLG|DV[ .]SDR)\\b"
-      }
-    },
-    {
-      "name": "HDR (undefined)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/sdr.json
+++ b/docs/json/radarr/cf/sdr.json
@@ -5,10 +5,28 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "HDR Formats",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": false,
+      "fields": {
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+      }
+    },
+    {
       "name": "SDR",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": true,
+      "required": false,
       "fields": {
         "value": "\\bSDR\\b"
       }

--- a/docs/json/sonarr/cf/2160p.json
+++ b/docs/json/sonarr/cf/2160p.json
@@ -14,30 +14,21 @@
       }
     },
     {
-      "name": "HDR",
+      "name": "HDR Formats",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
-      "required": false,
+      "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
       }
     },
     {
-      "name": "DV",
+      "name": "NOT SDR",
       "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
+      "negate": true,
+      "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision|DV[ .]HDR10|DV[ .]HLG|DV[ .]SDR)\\b"
-      }
-    },
-    {
-      "name": "HDR (undefined)",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bSDR\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/sdr.json
+++ b/docs/json/sonarr/cf/sdr.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "2016d1676f5ee13a5b7257ff86ac9a93",
+  "trash_score": "-10000",
+  "name": "SDR",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "2160p",
+      "implementation": "ResolutionSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": 2160
+      }
+    },
+    {
+      "name": "HDR Formats",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": false,
+      "fields": {
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+      }
+    },
+    {
+      "name": "SDR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\bSDR\\b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Pull request

**Purpose**
Change 2160p CFs to oneliners, update SDR with negated HDR formats

**Approach**
2160p now properly only matches HDR formats, and SDR correctly excludes HDR formats

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
