### PR TITLE
[Radarr] Update Radarr french cf

### DIFF
--- a/docs/Radarr/radarr-setup-quality-profiles-french-fr.md
+++ b/docs/Radarr/radarr-setup-quality-profiles-french-fr.md
@@ -1,7 +1,6 @@
 # Comment configurer ses Profiles
 
-!!! note
-    Ce guide a été créé et est maintenu par [Someone said "Nice"?](https://github.com/NiceTSY)
+!!! note "Ce guide a été créé et est maintenu par [Someone said "Nice"?](https://github.com/NiceTSY)"
 
 Quelle est la meilleure façon de configurer les Formats Personnalisés (ou Custom Formats) et lesquels utiliser avec quel score pour obtenir une release avec un audio français et un anglais ?
 
@@ -17,7 +16,7 @@ TRaSH a créé un [schéma](/Radarr/Radarr-setup-custom-formats/#which-quality-p
 
 ## Notions de base
 
-Il est très important que vous respectiez et compreniez ce qui est proposé par le guide de TRaSH (*en anglais uniquement*) :
+Il est impératif que vous respectiez et compreniez ce qui est proposé par le guide de TRaSH (*en anglais uniquement*) :
 
 - L'ajout de Formats Personnalisés, comme expliqué dans [How to import Custom Formats](/Radarr/Radarr-import-custom-formats/){:target="_blank" rel="noopener noreferrer"}.
 - La configuration d'un profil de qualité pour utiliser les formats personnalisés, comme expliqué dans la section [How to setup Quality Profiles | Basics section](/Radarr/Radarr-setup-custom-formats/#basics){:target="_blank" rel="noopener noreferrer"}.
@@ -26,7 +25,7 @@ Il est très important que vous respectiez et compreniez ce qui est proposé par
 
 !!! warning "Impératif"
 
-    La seule modification nécessaire et **indispensable** pour que les formats personnalisés français fonctionnent, est de définir le profil de langue sur `Any`.
+    La seule modification nécessaire et **indispensable** pour que les formats personnalisés français fonctionnent est de définir le profil de langue sur `Any`.
 
     ??? check "Exemple - [CLIQUEZ POUR AFFICHER]"
         ![!cf-quality-profile-cf](images/french-cf-profile-language.png)
@@ -44,7 +43,7 @@ Deux options s'offre à vous :
 
 !!! tip "Il s'agit de la méthode à privilégier."
 
-- Configurer Radarr en utilisant : [How to setup Quality Profiles | Which Quality Profile should you choose](/Radarr/radarr-setup-quality-profiles/#which-quality-profile-should-you-choose) (*en anglais*).
+- Configurez Radarr en utilisant : [How to setup Quality Profiles | Which Quality Profile should you choose](/Radarr/radarr-setup-quality-profiles/#which-quality-profile-should-you-choose) (*en anglais*).
 - Configurez [Bazarr](../Bazarr/Setup-Guide.md) (*en anglais*). Il permet d'obtenir des sous-titres pour tous les films.
 - Profitez de vos films avec les sous-titres.
 - (Facultatif) Ajoutez le Format Personnalisé [{{ radarr['cf']['french-vostfr']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#vostfr) avec un score de `1000`.

--- a/docs/json/radarr/cf/french-vfq.json
+++ b/docs/json/radarr/cf/french-vfq.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "b6ace47331a1d3b77942fc18156f6df6",
-  "trash_regex": "https://regex101.com/r/j1wmmv/2",
+  "trash_regex": "https://regex101.com/r/j1wmmv/3",
   "name": "VFQ",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(?<!Multi-)(FR(A|ENCH)?|VF)\\b"
+        "value": "\\b(?<=MULTi[ .])FR(A|ENCH)\\b"
       }
     },
     {
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bVFQ\\b"
+        "value": "\\b(VFQ?)\\b"
       }
     }
   ]

--- a/includes/french-guide/radarr-french-advanced-audio-information-fr.md
+++ b/includes/french-guide/radarr-french-advanced-audio-information-fr.md
@@ -3,7 +3,7 @@
 
     - Les règles de la Scène française stipulent que l'audio français doit être le premier audio (celui par défaut) dans une version MULTi.
     - Les règles stipulent que seul le meilleur son (qu'il soit original ou FR) doit être mentionné dans le titre.
-    - Certains films (et émissions de télévision, principalement de l'ère pré-streaming) ne disposent pas d'une piste audio FR équivalente à la piste la plus élevée de l'audio original.
+    - Certains films (et séries, principalement de l'ère pré-streaming) ne disposent pas d'une piste audio FR équivalente à la piste la plus élevée de l'audio original.
 
     En conséquence, les situations ci-après peuvent être observées :
 


### PR DESCRIPTION
# Pull request

**Purpose**
Corrected some French wording and grammar.
Corrected VFQ format to not recognise FRENCH alone. It needs now MULTi in front of it (but will not recognise the Multi-French format) so it should leave alone the French original movies.
This is still not bulletproof but should lead to less false positives.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
