### PR TITLE
Add Proper2 condition to v2 repack CFs, update Radarr Repack scores to match Sonarr, update MA score so not trumped by repacks, add PQ to HDR formats in 2160p and SDR CFs

### DIFF
--- a/docs/json/radarr/cf/2160p.json
+++ b/docs/json/radarr/cf/2160p.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/ma.json
+++ b/docs/json/radarr/cf/ma.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "2a6039655313bf5dab1e43523b62c374",
-  "trash_score": "10",
+  "trash_score": "15",
   "name": "MA",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/repack-proper.json
+++ b/docs/json/radarr/cf/repack-proper.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "e7718d7a3ce595f289bfee26adc178f5",
-  "trash_score": "5",
+  "trash_score": "11",
   "trash_regex": "https://regex101.com/r/S91wR8/2",
   "name": "Repack/Proper",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/repack2.json
+++ b/docs/json/radarr/cf/repack2.json
@@ -1,6 +1,6 @@
 {
   "trash_id": "ae43b294509409a6a13919dedd4764c4",
-  "trash_score": "6",
+  "trash_score": "12",
   "trash_regex": "https://regex101.com/r/kQ4oeP/1",
   "name": "Repack2",
   "includeCustomFormatWhenRenaming": false,

--- a/docs/json/radarr/cf/repack2.json
+++ b/docs/json/radarr/cf/repack2.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "ae43b294509409a6a13919dedd4764c4",
   "trash_score": "6",
+  "trash_regex": "https://regex101.com/r/kQ4oeP/1",
   "name": "Repack2",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,6 +12,15 @@
       "required": false,
       "fields": {
         "value": "\\b(Repack2)\\b"
+      }
+    },
+    {
+      "name": "Proper2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Proper2)\\b"
       }
     }
   ]

--- a/docs/json/radarr/cf/sdr.json
+++ b/docs/json/radarr/cf/sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/2160p.json
+++ b/docs/json/sonarr/cf/2160p.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/repack-v2.json
+++ b/docs/json/sonarr/cf/repack-v2.json
@@ -12,6 +12,15 @@
       "fields": {
         "value": "\\b(repack2)\\b"
       }
+    },
+    {
+      "name": "Proper v2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(proper2)\\b"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/sdr.json
+++ b/docs/json/sonarr/cf/sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b"
+        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX)\\b|\\b(PQ)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
Add Proper2 condition to v2 repack CFs, update Radarr Repack scores to match Sonarr, update MA score so not trumped by repacks, add PQ to HDR formats in 2160p and SDR CFs

**Approach**
So that proper2 releases are correctly identified, to standardise scoring, to keep MA prioritised, and so PQ releases dont get matched as SDR

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
