### PR TITLE
Update bad-dual-groups.json

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(-alfaHD[_]?)\\b"
+        "value": "\\b(-alfaHD.*$)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/bad-dual-groups.json
+++ b/docs/json/sonarr/cf/bad-dual-groups.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(-alfaHD[_]?)\\b"
+        "value": "\\b(-alfaHD.*$)\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
yesterdays update fetches alfaHD_ but not the ones with more underscores

Reference: https://regex101.com/r/0O67fi/1
