### PR TITLE
User/Pass clarification

### DIFF
--- a/docs/Prowlarr/prowlarr-setup-proxy.md
+++ b/docs/Prowlarr/prowlarr-setup-proxy.md
@@ -35,8 +35,8 @@ Add the following info
 1. The tags for this proxy. Proxies apply to all matching (same tag) indexers. If blank this proxy applies to all indexers.
 1. Host name to your torrent client.
 1. Used port for privoxy (default for privoxy: 8118).
-1. User name for your torrent client.
-1. Password for your torrent client.
+1. User name for your torrent client. (Not needed if using the default privoxy settings)
+1. Password for your torrent client. (Not needed if using the default privoxy settings)
 1. Test if your connection works.
 1. If it works click on `Save`.
 


### PR DESCRIPTION
User/pass for qbit privoxy is not needed. The servarr wiki instructions include user/pass because some http proxies may require them, this is not the case with privoxy specifically.

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
