### PR TITLE
Remove unnecessary DV FEL CF in SQP 4+5 recyclarr yml files

### DIFF
--- a/docs/SQP/yml/sqp-4.yml
+++ b/docs/SQP/yml/sqp-4.yml
@@ -39,7 +39,6 @@ radarr:
           - 9364dd386c9b4a1100dde8264690add7 # HLG
           # Movie Versions
           - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c # Remaster
           - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
           - e0c07d59beb37348e975a930d5e50319 # Criterion Collection

--- a/docs/SQP/yml/sqp-5.yml
+++ b/docs/SQP/yml/sqp-5.yml
@@ -39,7 +39,6 @@ radarr:
           - 9364dd386c9b4a1100dde8264690add7 # HLG
           # Movie Versions
           - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
           - 570bc9ebecd92723d2d21500f4be314c # Remaster
           - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
           - e0c07d59beb37348e975a930d5e50319 # Criterion Collection


### PR DESCRIPTION
# Pull request

**Purpose**
To remove erroneous DV FEL CF entries from SQP 4+5 recyclarr yml files

**Approach**
Removed the CFs

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
