### PR TITLE
Sonarr FR -  Update CF errors

### DIFF
--- a/docs/json/sonarr/cf/french-anime-fansub.json
+++ b/docs/json/sonarr/cf/french-anime-fansub.json
@@ -1,7 +1,7 @@
 {
-  "trash_id": "ddb8eaa9c85a549c50034d280539d54d",
+  "trash_id": "44b6c964dad997577d793fd004a39224",
   "trash_score": "1400",
-  "name": "FR WEB Tier 01",
+  "name": "FR Anime FanSub",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {

--- a/docs/json/sonarr/cf/french-canal.json
+++ b/docs/json/sonarr/cf/french-canal.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -18,7 +18,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {

--- a/docs/json/sonarr/cf/french-rtbf.json
+++ b/docs/json/sonarr/cf/french-rtbf.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -18,7 +18,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {

--- a/docs/json/sonarr/cf/french-salto.json
+++ b/docs/json/sonarr/cf/french-salto.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -18,7 +18,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {

--- a/docs/json/sonarr/cf/french-web-tier-01.json
+++ b/docs/json/sonarr/cf/french-web-tier-01.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {

--- a/docs/json/sonarr/cf/french-web-tier-02.json
+++ b/docs/json/sonarr/cf/french-web-tier-02.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {

--- a/docs/json/sonarr/cf/french-web-tier-03.json
+++ b/docs/json/sonarr/cf/french-web-tier-03.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 7
+        "value": 3
       }
     },
     {
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": 8
+        "value": 4
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
Sonarr: `FR Anime FanSub` had the same ID and name as `FR WEB Tier 01`
French WEBDL and WEBRIP had Radarr CF values (7and 8)

**Approach**
Name changed and new hash code generated with contribution directives.
I changed the value of WEBDL and WEBRIP to 3 and 4 and now they correspond to the right values.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [X] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
