### PR TITLE
[Radarr] Removed: `BiTOR`

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -59,6 +59,15 @@
       }
     },
     {
+      "name": "BiTOR",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BiTOR)\\b"
+      }
+    },
+    {
       "name": "C4K",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/uhd-bluray-tier-03.json
+++ b/docs/json/radarr/cf/uhd-bluray-tier-03.json
@@ -5,15 +5,6 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "BiTOR",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": false,
-      "required": false,
-      "fields": {
-        "value": "\\b(BiTOR)\\b"
-      }
-    },
-    {
       "name": "LEGi0N",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
- Moved: RlsGrp `BiTOR` from `UHD Bluray Tier 3` to `LQ`. Reason: Fake DV Layer: HDR10+ conversion.

