### PR TITLE
Use full semver for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
 
   - package-ecosystem: pip
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,11 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v3.0.0
+      - uses: actions/setup-python@v4.0.0
         with:
           python-version: 3.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.0.0
         with:
           key: ${{ github.ref }}
           path: .cache
@@ -25,13 +25,13 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.0
         with:
           fetch-depth: '0'
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4.0.0
         with:
           python-version: 3.x
-      - uses: actions/cache@v3
+      - uses: actions/cache@v3.0.0
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
   editorconfig-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.0
       - name: editorconfig-checker
         run: |
           docker run --rm \
@@ -17,7 +17,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.0
       - name: markdownlint
         run: |
           find "${GITHUB_WORKSPACE}" -name '*.md' -exec \
@@ -30,7 +30,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.0
       - name: yamllint
         run: |
           find "${GITHUB_WORKSPACE}" -name '*.yaml' -o -name '*.yml' -exec \

--- a/.github/workflows/metadata-validation.yml
+++ b/.github/workflows/metadata-validation.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate metadata.json
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v3.0.0
+      - uses: actions/setup-python@v4.0.0
         with:
           python-version: "3.x"
       - run: pip install jsonschema


### PR DESCRIPTION
# Pull request

**Purpose**
Using the full semver (ex: `v3.0.0` instead of `v3`) allows dependabot to open PRs to update to `v3.0.1` instead of waiting for `v4`

Also switch dependabot from `daily` to `weekly` to reduce the work it has to do.

**Approach**
Add `.0.0` to the end of all GitHub Actions. This will result in multiple follow up PRs from @dependabot to get caught up.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
