### PR TITLE
Update SQP YMLs to fix issue with CF deletions

### DIFF
--- a/docs/SQP/yml/sqp-1.yml
+++ b/docs/SQP/yml/sqp-1.yml
@@ -1,11 +1,10 @@
 radarr:
-  - base_url: [radarr_url_goes_here]
+  radarr-sqp-streaming:
+    base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
     quality_definition:
       type: sqp-streaming
-
-    delete_old_custom_formats: true
 
     custom_formats:
       # Scores from TRaSH json

--- a/docs/SQP/yml/sqp-2.yml
+++ b/docs/SQP/yml/sqp-2.yml
@@ -1,11 +1,10 @@
 radarr:
-  - base_url: [radarr_url_goes_here]
+  radarr-sqp-uhd:
+    base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
     quality_definition:
       type: sqp-uhd
-
-    delete_old_custom_formats: true
 
     custom_formats:
       # Scores from TRaSH json

--- a/docs/SQP/yml/sqp-3.yml
+++ b/docs/SQP/yml/sqp-3.yml
@@ -1,11 +1,10 @@
 radarr:
-  - base_url: [radarr_url_goes_here]
+  radarr-sqp-uhd:
+    base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
     quality_definition:
       type: sqp-uhd
-
-    delete_old_custom_formats: true
 
     custom_formats:
       # Scores from TRaSH json

--- a/docs/SQP/yml/sqp-4.yml
+++ b/docs/SQP/yml/sqp-4.yml
@@ -1,11 +1,10 @@
 radarr:
-  - base_url: [radarr_url_goes_here]
+  radarr-sqp-uhd:
+    base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
     quality_definition:
       type: sqp-uhd
-
-    delete_old_custom_formats: true
 
     custom_formats:
       # Scores from TRaSH json

--- a/docs/SQP/yml/sqp-5.yml
+++ b/docs/SQP/yml/sqp-5.yml
@@ -1,11 +1,10 @@
 radarr:
-  - base_url: [radarr_url_goes_here]
+  radarr-sqp-uhd:
+    base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
     quality_definition:
       type: sqp-uhd
-
-    delete_old_custom_formats: true
 
     custom_formats:
       # Scores from TRaSH json


### PR DESCRIPTION
# Pull request

**Purpose**
When running recyclarr in configs mode (i.e., using multiple config files from the configs folder), if `delete_old_custom_formats` is enabled in a config file then specified CFs can potentially be deleted. This is because each file is processed in turn, and if there are CFs loaded by any of your preceeding files and not the last one then any CFs that are called in the last file can be deleted as they're seen as 'old' CFs.

**Approach**
Removed `delete_old_custom_formats` from all SQP config files. Have also specified radarr instance names for better identification when running.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
