### PR TITLE
exclude hdr10+ from DV HDR10 CF

### DIFF
--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e23edd2482476e595fb990b12e7c609c",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/pADWJD/5",
+  "trash_regex": "https://regex101.com/r/pADWJD/8",
   "name": "DV HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -20,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -20,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "7878c33f1963fefb3d6c8657d46c2f0a",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/pADWJD/5",
+  "trash_regex": "https://regex101.com/r/pADWJD/8",
   "name": "DV HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/sonarr/cf/dv-hlg.json
+++ b/docs/json/sonarr/cf/dv-hlg.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-sdr.json
+++ b/docs/json/sonarr/cf/dv-sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/hdr10plus-boost.json
@@ -20,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10plus.json
+++ b/docs/json/sonarr/cf/hdr10plus.json
@@ -20,7 +20,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?)\\b)(?=.*\\b(DV|DoVi)\\b)"
+        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
The "DV HDR10" currently matches with "DV.HDR10" and "DV.HDR10+", but not "DV.HDR10Plus". This is to update the CF to be consistent and only match with "DV.HDR10"

**Approach**
This is the current regex https://regex101.com/r/YQXE5R/1
This is the new regex https://regex101.com/r/KQO62Q/1
It only matches "DV.HDR10"

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
