### PR TITLE
Add preferred quality note to Sonarr filesize page

### DIFF
--- a/docs/Sonarr/Sonarr-Quality-Settings-File-Size.md
+++ b/docs/Sonarr/Sonarr-Quality-Settings-File-Size.md
@@ -80,4 +80,11 @@ I only do WEB-DL myself for TV shows because in my opinion WEB-DL is the sweet s
 | {{ sonarr['quality-size']['anime']['qualities'][17]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][17]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][17]['max'] }} |
 | {{ sonarr['quality-size']['anime']['qualities'][18]['quality'] }} | {{ sonarr['quality-size']['anime']['qualities'][18]['min'] }} | {{ sonarr['quality-size']['anime']['qualities'][18]['max'] }} |
 
+!!! note
+    The reason why you don't see the `Preferred` score in the table above is because we want max quality anyway. So set it as high as possible.
+
+    The highest preferred quality you can manually enter is 1 less than the Maximum quality. If you use the slider, the preferred quality can be up to 5 lesser than the Maximum quality.
+
+    Make sure you have enabled 'Show Advanced' in Sonarr, if you don't see a provision to enter the scores, under the Quality settings.
+
 --8<-- "includes/support.md"


### PR DESCRIPTION
Add the preferred quality note from the Radarr page (amended to say Sonarr)

# Pull request

**Purpose**
User had a question in Discord about the preferred sizes for Sonarr, noticed that this note wasn't on the Sonarr page.

**Approach**
Copy the note panel from the Radarr page, change name to Sonarr

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
