### PR TITLE
Add trash_ids for Sonarr anime release profiles

### DIFF
--- a/docs/json/sonarr/rp/visorakAnimeOne.json
+++ b/docs/json/sonarr/rp/visorakAnimeOne.json
@@ -6,18 +6,21 @@
   "required": [],
   "preferred": [{
       "score": 1000,
+      "trash_id": "631c01b64f047f31576d1a83d3ed51bc",
       "terms": [
         "/(uncut|unrated|uncensored|\\b(AT[-_. ]?X)\\b)/i"
       ]
     },
     {
       "score": 500,
+      "trash_id": "cc086f9dbb91e74e18eceada4c430f0d",
       "terms": [
         "/(multi[ ._-]?audio)/i"
       ]
     },
     {
       "score": 0,
+      "trash_id": "e9f00551013419415493fb2366c7f618",
       "terms": [
         "/(dual[ ._-]?audio)/i"
       ]

--- a/docs/json/sonarr/rp/visorakAnimeOne.json
+++ b/docs/json/sonarr/rp/visorakAnimeOne.json
@@ -4,7 +4,9 @@
   "community_id": "Visorak",
   "includePreferredWhenRenaming": true,
   "required": [],
-  "preferred": [{
+  "preferred": [
+    {
+      "name": "Uncensored",
       "score": 1000,
       "trash_id": "631c01b64f047f31576d1a83d3ed51bc",
       "terms": [
@@ -12,6 +14,7 @@
       ]
     },
     {
+      "name": "Multi Audio",
       "score": 500,
       "trash_id": "cc086f9dbb91e74e18eceada4c430f0d",
       "terms": [
@@ -19,6 +22,7 @@
       ]
     },
     {
+      "name": "Dual Audio",
       "score": 0,
       "trash_id": "e9f00551013419415493fb2366c7f618",
       "terms": [

--- a/docs/json/sonarr/rp/visorakAnimeOne.json
+++ b/docs/json/sonarr/rp/visorakAnimeOne.json
@@ -4,29 +4,30 @@
   "community_id": "Visorak",
   "includePreferredWhenRenaming": true,
   "required": [],
-  "preferred": [
-    {
-      "name": "Uncensored",
+  "preferred": [{
       "score": 1000,
-      "trash_id": "631c01b64f047f31576d1a83d3ed51bc",
-      "terms": [
-        "/(uncut|unrated|uncensored|\\b(AT[-_. ]?X)\\b)/i"
-      ]
+      "terms": [{
+          "name": "Uncensored",
+          "trash_id": "631c01b64f047f31576d1a83d3ed51bc",
+          "term": "/(uncut|unrated|uncensored|\\b(AT[-_. ]?X)\\b)/i"
+        }]
     },
     {
-      "name": "Multi Audio",
       "score": 500,
-      "trash_id": "cc086f9dbb91e74e18eceada4c430f0d",
-      "terms": [
-        "/(multi[ ._-]?audio)/i"
-      ]
+      "terms": [{
+          "name": "Multi Audio",
+          "trash_id": "cc086f9dbb91e74e18eceada4c430f0d",
+          "term": "/(multi[ ._-]?audio)/i"
+      }]
     },
     {
-      "name": "Dual Audio",
       "score": 0,
-      "trash_id": "e9f00551013419415493fb2366c7f618",
-      "terms": [
-        "/(dual[ ._-]?audio)/i"
+      "terms": [{
+        "name": "Dual Audio",
+        "trash_id": "e9f00551013419415493fb2366c7f618",
+        "term": "/(dual[ ._-]?audio)/i"
+      }
+        
       ]
     }
   ],

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -255,7 +255,12 @@
     {
       "name": "Dub releases",
       "trash_id": "9e41abe215f5d25b6d7545306c8abe39",
-      "term": "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i,/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
+      "term": "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i"
+    },
+    {
+      "name": "Dub release groups",
+      "trash_id": "8b584aa2da17542d5ad6f861792fefe0",
+      "term": "/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
     }
   ]
 }

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -180,8 +180,9 @@
     {
       "name": "Low quality",
       "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
-      "terms": [
-        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
+      "term": [
+        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i",
+        "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i"
       ]
     },
     {

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -178,9 +178,79 @@
   ],
   "ignored": [
     {
-      "name": "Low quality",
-      "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
+      "name": "Low quality - EMBER, DaddySubs",
+      "trash_id": "a3810b8af452d1ea9b686aa28236b256",
       "term": "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
+    },
+    {
+      "name": "Low quality - BDMV, M2TS, bSSA, bVOSTFR, bAbemaTV",
+      "trash_id": "f71e08b03f10ce996263a2922741501c",
+      "term": "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i"
+    },
+    {
+      "name": "Low quality - CuaP, PnPSubs, ICEBLUE, SLAX, U3-Web",
+      "trash_id": "96cacca3bb04ce9ac45cad15b06e2253",
+      "term": "/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i"
+    },
+    {
+      "name": "Low quality - Raws-Maji, KRP, M@nI, Kanjouteki, PuyaSubs",
+      "trash_id": "a4739d8a425cd14f8fd6c3b8fe927d3e",
+      "term": "/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i"
+    },
+    {
+      "name": "Low quality - Beatrice-raws, ohys-raws, Kawaiika-raws, neko-raws, daddy-raws",
+      "trash_id": "c14eb80e6a22c2ccef7b1c5395255fd5",
+      "term": "/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i"
+    },
+    {
+      "name": "Low quality - LowPower-raws, Scryous-raws",
+      "trash_id": "8ff78e62b359787bc09f9ab91aa90270",
+      "term": "/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i"
+    },
+    {
+      "name": "Low quality - NS, AREY, BDMV, BDVD, BJX, DKB, DP, TnF",
+      "trash_id": "076c295f56c0c51ea2a124c5b536338e",
+      "term": "/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i"
+    },
+    {
+      "name": "Low quality - Amb3r, DsunS, ExREN, $tore-Chill",
+      "trash_id": "377f7c867aeb02e40bafa9beb0ecb79b",
+      "term": "/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i"
+    },
+    {
+      "name": "Low quality - Hatsuyuki, Hitoku",
+      "trash_id": "ef4a5baa93d13b3ffd839bd2b8175a03",
+      "term": "/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i"
+    },
+    {
+      "name": "Low quality - Foxtrot, HollowRoxas, MGD",
+      "trash_id": "4f3058ee6dc30d6559e828ab37be9981",
+      "term": "/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i"
+    },
+    {
+      "name": "Low quality - JacobSwaggedUp, KEKMASTERS, Mites",
+      "trash_id": "96411893d02c8a46c221e364b4b8bdac",
+      "term": "/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i"
+    },
+    {
+      "name": "Low quality - neoHEVC, Pantsu, Pao, Plex Friendly",
+      "trash_id": "90bc8d0b83c22b291b575c793e6d24e0",
+      "term": "/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i"
+    },
+    {
+      "name": "Low quality - Rando235, RandomRemux, Reaktor, RightShiftBy2",
+      "trash_id": "7d71872f1705637722da72749be042dc",
+      "term": "/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i"
+    },
+    {
+      "name": "Low quality - SHFS, StrayGods, UQW, Yabai_Desu_Ne",
+      "trash_id": "498994b7382c73e38907166b4bb6c0c4",
+      "term": "/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i"
+    },
+    {
+      "name": "Low quality - YakuboEncodes, WtF-Anime",
+      "trash_id": "bcbe5f24625e520334281d7901f8f6eb",
+      "term": "/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i"
     },
     {
       "name": "Dub releases",

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -4,7 +4,8 @@
   "community_id": "Visorak",
   "includePreferredWhenRenaming": false,
   "required": [],
-  "preferred": [{
+  "preferred": [
+    {
       "score": 4000,
       "terms": [
         "/(deanzel|\\bZR\\b|\\bCTR\\b|\\bSCY\\b|\\bMK\\b|TTGA)/i",
@@ -178,32 +179,13 @@
   "ignored": [
     {
       "name": "Low quality",
-      "trash_id": "cec8880b847dd5d31d29167ee0112b57",
-      "terms": [
-        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i",
-        "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i",
-        "/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i",
-        "/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i",
-        "/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i",
-        "/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i",
-        "/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i",
-        "/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i",
-        "/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i",
-        "/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i",
-        "/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i",
-        "/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i",
-        "/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i",
-        "/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i",
-        "/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i"
-      ]
+      "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
+      "term": "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i,/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i,/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i,/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i,/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i,/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i,/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i,/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i,/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i,/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i,/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i,/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i,/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i,/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i,/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i"
     },
     {
       "name": "Dub releases",
-      "trash_id": "cec8880b847dd5d31d29167ee0112b57",
-      "terms": [
-        "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i",
-        "/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
-      ]
+      "trash_id": "9e41abe215f5d25b6d7545306c8abe39",
+      "term": "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i,/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
     }
   ]
 }

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -176,22 +176,34 @@
     }
   ],
   "ignored": [
-    "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i",
-    "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i",
-    "/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i",
-    "/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i",
-    "/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i",
-    "/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i",
-    "/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i",
-    "/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i",
-    "/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i",
-    "/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i",
-    "/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i",
-    "/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i",
-    "/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i",
-    "/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i",
-    "/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i",
-    "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i",
-    "/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
+    {
+      "name": "Low quality",
+      "trash_id": "cec8880b847dd5d31d29167ee0112b57",
+      "terms": [
+        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i",
+        "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i",
+        "/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i",
+        "/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i",
+        "/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i",
+        "/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i",
+        "/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i",
+        "/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i",
+        "/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i",
+        "/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i",
+        "/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i",
+        "/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i",
+        "/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i",
+        "/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i",
+        "/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i"
+      ]
+    },
+    {
+      "name": "Dub releases",
+      "trash_id": "cec8880b847dd5d31d29167ee0112b57",
+      "terms": [
+        "/((funi|eng(lish)?)_?dub|\\bdub(bed)?\\b)/i",
+        "/(Golumpa|torenter69|KamiFS|KaiDubs)/i"
+      ]
+    }
   ]
 }

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -180,9 +180,7 @@
     {
       "name": "Low quality",
       "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
-      "term": [
-        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
-      ]
+      "term": "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
     },
     {
       "name": "Dub releases",

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -181,8 +181,7 @@
       "name": "Low quality",
       "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
       "term": [
-        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i",
-        "/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i"
+        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
       ]
     },
     {

--- a/docs/json/sonarr/rp/visorakAnimeTwo.json
+++ b/docs/json/sonarr/rp/visorakAnimeTwo.json
@@ -180,7 +180,9 @@
     {
       "name": "Low quality",
       "trash_id": "12f1074e8d33d90e56ab46f2b2c675ee",
-      "term": "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i,/(BDMV|M2TS|\\bSSA\\b|\\bVOSTFR\\b|\\bAbemaTV\\b)/i,/(CuaP|PnPSubs|ICEBLUE|SLAX|U3-Web)/i,/(Raws-Maji|\\bKRP\\b|M@nI|Kanjouteki|PuyaSubs)/i,/\\b(Beatrice|ohys|Kawaiika|neko|daddy)[ ._-]?(raws)\\b/i,/\\b(LowPower|Scryous)[ ._-]?(raws)\\b/i,/\\b(NS|AREY|BDMV|BDVD|BJX|DKB|DP|TnF)\\b/i,/(Amb3r|DsunS|ExREN|\\$tore-Chill)/i,/(\\[Hatsuyuki\\]|-Hatsuyuki\\b|\\[Hitoku\\]|-Hitoki\\b)/i,/(\\[Foxtrot\\]|-Foxtrot\\b|HollowRoxas|\\bMGD\\b)/i,/(JacobSwaggedUp|KEKMASTERS|\\[Mites\\]|-Mites\\b)/i,/(neoHEVC|Pantsu|\\[Pao\\]|-Pao\\b|Plex Friendly)/i,/(Rando235|RandomRemux|Reaktor|RightShiftBy2)/i,/(\\bSHFS\\b|StrayGods|\\bUQW\\b|Yabai_Desu_Ne)/i,/(YakuboEncodes|\\b(WtF[ ._-]?Anime)\\b)/i"
+      "terms": [
+        "/(\\[EMBER\\]|-EMBER\\b|DaddySubs)/i"
+      ]
     },
     {
       "name": "Dub releases",


### PR DESCRIPTION
# Pull request

**Purpose**
In the guide for [Sonarr anime release profiles](https://trash-guides.info/Sonarr/Sonarr-Release-Profile-RegEx-Anime), there are some terms intended to be optional - 
[Uncensored](https://trash-guides.info/Sonarr/Sonarr-Release-Profile-RegEx-Anime/#optional-uncutunrateduncensored) and [Dub releases](https://trash-guides.info/Sonarr/Sonarr-Release-Profile-RegEx-Anime/#must-not-contain)
However these didn't have trash_ids so couldn't be filtered

**Approach**
Update the visorakAnime release profile jsons with Names and trash_ids

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed


**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
