### PR TITLE
Change Anime tiers to exclude Tsundere-Raws.

### DIFF
--- a/docs/json/sonarr/cf/anime-bd-tier-04-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-04-seadex-muxers.json
@@ -397,7 +397,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Tsundere\\]|-Tsundere\\b"
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/sonarr/cf/anime-web-tier-06-fansubs.json
@@ -82,7 +82,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Tsundere\\]|-Tsundere\\b"
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull request

**Purpose**

French release group matches "Anime Web Tier 06" and "Anime BD Tier 04" by mistake. Incoporate changes to exclude Tsundere-Raws being matched as Tsundere. 

Change is borrowed from discord in the message of rg9400:

https://discord.com/channels/492590071455940612/934222763709833217/1059948136103157870

**Approach**
This will lower the score of Tsundere-Raws releases to 0 if they forget to include VOSFTR.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
