### PR TITLE
Exclude Tsundere-Raws from radarr cf's

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-04-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-04-seadex-muxers.json
@@ -388,7 +388,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Tsundere\\]|-Tsundere\\b"
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
+++ b/docs/json/radarr/cf/anime-web-tier-06-fansubs.json
@@ -73,7 +73,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\[Tsundere\\]|-Tsundere\\b"
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull request

**Purpose**

I forgot to push the change to exclude tsundere-raws from radarr anime cf.

**Approach**

It is the same as the previous pr.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
