### PR TITLE
 Maintenance-Release-20230122

### DIFF
--- a/docs/json/radarr/cf/dv-webdl.json
+++ b/docs/json/radarr/cf/dv-webdl.json
@@ -37,7 +37,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(SiC|Flights)\\b"
+        "value": "\\b(Flights)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/opus.json
+++ b/docs/json/radarr/cf/opus.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "a061e2e700f81932daf888599f8a8273",
   "trash_score": "250",
+  "trash_regex": "https://regex101.com/r/SsIWo3/1",
   "name": "Opus",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
@@ -9,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-          "value": "\\bOPUS(\\b|\\d)"
+          "value": "\\bOPUS(\\b|\\d)(?!.*[ ._-](\\d{3,4}p))"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-webdl.json
+++ b/docs/json/sonarr/cf/dv-webdl.json
@@ -37,7 +37,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(SiC|Flights)\\b"
+        "value": "\\b(Flights)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/opus.json
+++ b/docs/json/sonarr/cf/opus.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "28f6ef16d61e2d1adfce3156ed8257e3",
   "trash_score": "250",
+  "trash_regex": "https://regex101.com/r/SsIWo3/1",
   "name": "Opus",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [{
@@ -9,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-          "value": "\\bOPUS(\\b|\\d)"
+          "value": "\\bOPUS(\\b|\\d)(?!.*[ ._-](\\d{3,4}p))"
       }
     },
     {

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,23 @@
+# 2023-01-22 19:45
+*[New]*
+- None
+
+**[Updated]**
+- [Guide-FR] Reworded the Bazarr option for Anime.
+- [Guide- and Sonarr-FR] Synced change from Original Anime Guide to French Anime Guide (added `Tsundere-Raws` to tier 01).
+- [Starr-FR] Removed `KOGi` from French Scene.
+- [Starr-FR] added `Dropse` to `LQ` as they Retag/Rename some Full Bluray disc to Bluray encode.
+- [Starr-FR] added `GLaDOS` to `LQ` due to audio upmix or fake soundtrack and poor quality encoding.
+- [Sonarr-FR] Updated French Anime FanSub Tier.
+- [Sonarr-FR] Updated French Anime Tiers CF.
+- [Sonarr-FR] Removed the `FR Anime Tier Optional` as it is no more really needed.
+
+**[Fixed]**
+- [Sonarr-FR] Fixed misslabeled Specification for Sonarr Bluray and Remux Tiers.
+- [Sonarr-FR] Fixed score to `-10000` for `FastSub`.
+- [Starr] Prevent CF `Opus` (audio) to be matched if Opus is in the release name. (Mainly for Sonarr being the regex matching starts after Episode number, but also added it to Radarr CF to be consistent + Added: regex example).
+- [Starr] Remove RlsGrp `SiC` from CF `DV (WEBDL)` being they now also do DV only.
+
 # 2023-01-19 23:30
 **[New]**
 - None


### PR DESCRIPTION
- [Starr] Prevent CF `Opus` (audio) to be matched if Opus is in the release name. (Mainly for Sonarr being the regex matching starts after Episode number, but also added it to Radarr CF to be consistent + Added: regex example).
- [Starr] Remove RlsGrp `SiC` from CF `DV (WEBDL)` being they now also do DV only.
