### PR TITLE
feat(anime) - add LYS1TH3A to the Anime tiers

### DIFF
--- a/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/radarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -212,6 +212,15 @@
       }
     },
     {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
       "name": "Matsya",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/radarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/radarr/cf/anime-web-tier-01-muxers.json
@@ -50,6 +50,15 @@
       }
     },
     {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
       "name": "Reza",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
+++ b/docs/json/sonarr/cf/anime-bd-tier-02-seadex-muxers.json
@@ -221,6 +221,15 @@
       }
     },
     {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
       "name": "Matsya",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,

--- a/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
+++ b/docs/json/sonarr/cf/anime-web-tier-01-muxers.json
@@ -59,6 +59,15 @@
       }
     },
     {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
       "name": "Reza",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Adding LYS1TH3A to BD tier 02 and Web Tier 01

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
