### PR TITLE
Fix HBO/HMAX inconsistencies across Sonarr V3/V4 and Radarr, Fix HBO rlsgrp matching HBO/HMAX Streaming CF

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -52,13 +52,14 @@ I also made 3 guides related to this one.
 | [Hybrid](#hybrid)                             | [BR-DISK](#br-disk)   | [Remux Tier 01](#remux-tier-01)           | [Amazon](#amzn)        |
 | [Remaster](#remaster)                         | [LQ](#lq)             | [Remux Tier 02](#remux-tier-02)           | [Apple TV+](#atvp)     |
 | [4K Remaster](#4k-remaster)                   | [3D](#3d)             | [UHD Bluray Tier 01](#uhd-bluray-tier-01) | [Disney+](#dsnp)       |
-| [Special Edition](#special-edition)           | [x265 (HD)](#x265-hd) | [UHD Bluray Tier 02](#uhd-bluray-tier-02) | [HBO Max](#hmax)       |
-| [Criterion Collection](#criterion-collection) |                       | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [Hulu](#hulu)          |
-| [Masters of Cinema](#masters-of-cinema)       |                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [Netflix](#nf)         |
-| [Theatrical Cut](#theatrical-cut)             |                       | [HD Bluray Tier 02](#hd-bluray-tier-02)   | [Peacock TV](#pcok)    |
-| [IMAX](#imax)                                 |                       | [WEB Tier 01](#web-tier-01)               | [Paramount+](#pmtp)    |
-| [IMAX Enhanced](#imax-enhanced)               |                       | [WEB Tier 02](#web-tier-02)               | [Movies Anywhere](#ma) |
-| [Open Matte](#open-matte)                     |                       | [WEB Tier 03](#web-tier-03)               | [Pathe Thuis](#pathe)  |
+| [Special Edition](#special-edition)           | [x265 (HD)](#x265-hd) | [UHD Bluray Tier 02](#uhd-bluray-tier-02) | [HBO](#hbo)            |
+| [Criterion Collection](#criterion-collection) |                       | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [HBO Max](#hmax)       |
+| [Masters of Cinema](#masters-of-cinema)       |                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [Hulu](#hulu)          |
+| [Theatrical Cut](#theatrical-cut)             |                       | [HD Bluray Tier 02](#hd-bluray-tier-02)   | [Netflix](#nf)         |
+| [IMAX](#imax)                                 |                       | [WEB Tier 01](#web-tier-01)               | [Peacock TV](#pcok)    |
+| [IMAX Enhanced](#imax-enhanced)               |                       | [WEB Tier 02](#web-tier-02)               | [Paramount+](#pmtp)    |
+| [Open Matte](#open-matte)                     |                       | [WEB Tier 03](#web-tier-03)               | [Movies Anywhere](#ma) |
+|                                               |                       |                                           | [Pathe Thuis](#pathe)  |
 |                                               |                       |                                           | [Bravia Core](#bcore)  |
 |                                               |                       |                                           | [Stan](#stan)          |
 

--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -1564,6 +1564,24 @@ I also made 3 guides related to this one.
 
 ------
 
+### HBO
+
+<sub>HBO</sub>
+
+??? question "HBO - [CLICK TO EXPAND]"
+
+    [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/HBO){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/hbo.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
 ### HMAX
 
 <sub>HBO Max</sub>

--- a/docs/Radarr/recyclarr-config/hd_bluray_web.yml
+++ b/docs/Radarr/recyclarr-config/hd_bluray_web.yml
@@ -43,6 +43,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/Radarr/recyclarr-config/remux_web_1080p.yml
+++ b/docs/Radarr/recyclarr-config/remux_web_1080p.yml
@@ -58,6 +58,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/Radarr/recyclarr-config/remux_web_2160p.yml
+++ b/docs/Radarr/recyclarr-config/remux_web_2160p.yml
@@ -73,6 +73,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/Radarr/recyclarr-config/uhd_bluray_web.yml
+++ b/docs/Radarr/recyclarr-config/uhd_bluray_web.yml
@@ -74,6 +74,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/SQP/yml/sqp-1.yml
+++ b/docs/SQP/yml/sqp-1.yml
@@ -77,6 +77,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/SQP/yml/sqp-2.yml
+++ b/docs/SQP/yml/sqp-2.yml
@@ -101,6 +101,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/SQP/yml/sqp-3.yml
+++ b/docs/SQP/yml/sqp-3.yml
@@ -98,6 +98,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/SQP/yml/sqp-4.yml
+++ b/docs/SQP/yml/sqp-4.yml
@@ -97,6 +97,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/SQP/yml/sqp-5.yml
+++ b/docs/SQP/yml/sqp-5.yml
@@ -100,6 +100,7 @@ radarr:
           - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
           - 40e9380490e748672c2522eaaeb692f7 # ATVP
           - 84272245b2988854bfb76a16e60baea5 # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515 # HBO
           - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
           - 526d445d4c16214309f0fd2b3be18a89 # Hulu
           - 170b1d363bd8516fbf3a3eb05d4faff6 # NF

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -163,7 +163,7 @@ Add this to your `Preferred (3)` with a score of [90]
 ```
 
 ```bash
-/\b(hmax|hbom|hbo max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+/\b(hmax|hbom|hbo[-_. ]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 Add this to your `Preferred (3)` with a score of [85]
@@ -183,7 +183,7 @@ Add this to your `Preferred (3)` with a score of [75]
 ```
 
 ```bash
-/\b(hbo)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+/\b(hbo)(?![-_. ]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 ```bash

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -163,7 +163,7 @@ Add this to your `Preferred (3)` with a score of [90]
 ```
 
 ```bash
-/\b(hmax|hbom|hbo[-_. ]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+/\b(hmax|hbom|hbo[ ._-]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 Add this to your `Preferred (3)` with a score of [85]
@@ -183,7 +183,7 @@ Add this to your `Preferred (3)` with a score of [75]
 ```
 
 ```bash
-/\b(hbo)(?![-_. ]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+/\b(hbo)(?![ ._-]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
 ```bash

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "509e5f41146e278f9eab1ddaceb34515"
+  "trash_id": "509e5f41146e278f9eab1ddaceb34515",
   "name": "HBO",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "509e5f41146e278f9eab1ddaceb34515"
+  "name": "HBO",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "HBO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/radarr/cf/hbo.json
+++ b/docs/json/radarr/cf/hbo.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hmax.json
+++ b/docs/json/radarr/cf/hmax.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|HBO Max)\\b"
+        "value": "\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![-_. ]max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+        "value": "\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -30,6 +30,15 @@
       "fields": {
         "value": 4
       }
+    },
+    {
+      "name": "HBO",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(HBO)\\b"
+      }
     }
   ]
 }

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![-_. ]max)\\b"
+        "value": "\\b(hbo)(?![-_. ]max)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {
@@ -29,15 +29,6 @@
       "required": false,
       "fields": {
         "value": 4
-      }
-    },
-    {
-      "name": "HBO",
-      "implementation": "ReleaseGroupSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HBO)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hbo.json
+++ b/docs/json/sonarr/cf/hbo.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo max)\\b"
+        "value": "\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hmax.json
+++ b/docs/json/sonarr/cf/hmax.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+        "value": "\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -22,7 +22,7 @@
         "/\\b(dsnp|dsny|disney|Disney\\+)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(nf|netflix)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(qibi|quibi)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     },
     {
@@ -36,7 +36,7 @@
       "score": 75,
       "terms": [
         "/\\b(dcu)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(hbo)(?![ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(red)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(it)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(pmtp)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -22,7 +22,7 @@
         "/\\b(dsnp|dsny|disney|Disney\\+)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(nf|netflix)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(qibi|quibi)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(hmax|hbom|hbo max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(hmax|hbom|hbo[-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     },
     {
@@ -36,7 +36,7 @@
       "score": 75,
       "terms": [
         "/\\b(dcu)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(hbo)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(hbo)(?![-_. ]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(red)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(it)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(pmtp)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -5,6 +5,7 @@
     | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   | 0                                          | {{ radarr['cf']['atvp']['trash_id'] }}  |
     | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | {{ radarr['cf']['bcore']['trash_score'] }} | {{ radarr['cf']['bcore']['trash_id'] }} |
     | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   | 0                                          | {{ radarr['cf']['dsnp']['trash_id'] }}  |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     | 0                                          | {{ radarr['cf']['hbo']['trash_id'] }}  |
     | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   | 0                                          | {{ radarr['cf']['hmax']['trash_id'] }}  |
     | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   | 0                                          | {{ radarr['cf']['hulu']['trash_id'] }}  |
     | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       | {{ radarr['cf']['ma']['trash_score'] }}    | {{ radarr['cf']['ma']['trash_id'] }}    |

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -5,7 +5,7 @@
     | [{{ radarr['cf']['atvp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#atvp)   | 0                                          | {{ radarr['cf']['atvp']['trash_id'] }}  |
     | [{{ radarr['cf']['bcore']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#bcore) | {{ radarr['cf']['bcore']['trash_score'] }} | {{ radarr['cf']['bcore']['trash_id'] }} |
     | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   | 0                                          | {{ radarr['cf']['dsnp']['trash_id'] }}  |
-    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     | 0                                          | {{ radarr['cf']['hbo']['trash_id'] }}  |
+    | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     | 0                                          | {{ radarr['cf']['hbo']['trash_id'] }}   |
     | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   | 0                                          | {{ radarr['cf']['hmax']['trash_id'] }}  |
     | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   | 0                                          | {{ radarr['cf']['hulu']['trash_id'] }}  |
     | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       | {{ radarr['cf']['ma']['trash_score'] }}    | {{ radarr['cf']['ma']['trash_id'] }}    |


### PR DESCRIPTION
# Pull request

**Purpose**
There are inconsistencies between the HBO and HBO Max custom formats across the Sonarr V3/V4 and Radarr guides, and also the Sonarr V4 HBO CF was matching any release from the HBO rlsgrp.

**Approach**
- Apply consistent regexes across all areas of the guide, including conditionals for matching the streaming service only
- Created a new HBO Radarr CF for matching older HBO (not HMAX) releases
- Update relevant guide pages and recyclarr configs

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
