### PR TITLE
Update SQP recyclarr configs with optional x264 comment

### DIFF
--- a/docs/SQP/yml/sqp-2.yml
+++ b/docs/SQP/yml/sqp-2.yml
@@ -90,6 +90,7 @@ radarr:
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
             # score: 0 # overrides default of -10000
+      # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
           - 2899d84dc9372de3408e6d8cc18e9666 # x264

--- a/docs/SQP/yml/sqp-3.yml
+++ b/docs/SQP/yml/sqp-3.yml
@@ -87,6 +87,7 @@ radarr:
         quality_profiles:
           - name: Remux|IMAX-E|2160p
             # score: 0 # overrides default of -10000
+      # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
           - 2899d84dc9372de3408e6d8cc18e9666 # x264

--- a/docs/SQP/yml/sqp-4.yml
+++ b/docs/SQP/yml/sqp-4.yml
@@ -86,6 +86,7 @@ radarr:
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
             # score: 0 # overrides default of -10000
+      # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
           - 2899d84dc9372de3408e6d8cc18e9666 # x264

--- a/docs/SQP/yml/sqp-5.yml
+++ b/docs/SQP/yml/sqp-5.yml
@@ -89,6 +89,7 @@ radarr:
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
             # score: 0 # overrides default of -10000
+      # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
           - 2899d84dc9372de3408e6d8cc18e9666 # x264


### PR DESCRIPTION
# Pull request

**Purpose**
To update the SQP recyclarr configs to add a comment for optionally disabling the x264 CF to match the updated guide pages

**Approach**
Add a comment to each YML file advising users to comment out the appropriate code block to disable the x264 CF

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
