### PR TITLE
feat(sonarr): added `Comedy Central` CF

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -210,6 +210,10 @@ Add this to your `Preferred (3)` with a score of [75]
 /\b(nlz)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
+```bash
+/\b(cc)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
 !!! danger "Caution"
     Don't forget to click on `SAVE` after you've added everything you want to the release profile :bangbang:
 

--- a/docs/Sonarr/recyclarr-config/web_1080p_v4.yml
+++ b/docs/Sonarr/recyclarr-config/web_1080p_v4.yml
@@ -36,6 +36,7 @@ sonarr:
           - ae58039e1319178e6be73caab5c42166  # SHO
           - 1efe8da11bfd74fbbcd4d8117ddb9213  # STAN
           - 5d2317d99af813b6529c7ebf01c83533  # VDL
+          - 77a7b25585c18af08f60b1547bb9b4fb  # CC
           # HQ Source Groups
           - e6258996055b9fbab7e9cb2f75819294  # WEB Tier 01
           - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02

--- a/docs/Sonarr/recyclarr-config/web_2160p_v4.yml
+++ b/docs/Sonarr/recyclarr-config/web_2160p_v4.yml
@@ -51,6 +51,7 @@ sonarr:
           - ae58039e1319178e6be73caab5c42166  # SHO
           - 1efe8da11bfd74fbbcd4d8117ddb9213  # STAN
           - 5d2317d99af813b6529c7ebf01c83533  # VDL
+          - 77a7b25585c18af08f60b1547bb9b4fb  # CC
           # HQ Source Groups
           - e6258996055b9fbab7e9cb2f75819294  # WEB Tier 01
           - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -45,28 +45,29 @@ I also made 3 guides related to this one.
 
 ------
 
-| Series Versions       | Unwanted              | HQ Source Groups                        | Streaming Services   |
-| --------------------- | --------------------- | --------------------------------------- | -------------------- |
-| [Hybrid](#hybrid)     | [BR-DISK](#br-disk)   | [Remux Tier 01](#remux-tier-01)         | [Amazon](#amzn)      |
-| [Remaster](#remaster) | [LQ](#lq)             | [Remux Tier 02](#remux-tier-02)         | [Apple TV+](#atvp)   |
-|                       | [x265 (HD)](#x265-hd) | [HD Bluray Tier 01](#hd-bluray-tier-01) | [DC Universe](#dcu)  |
-|                       |                       | [HD Bluray Tier 02](#hd-bluray-tier-02) | [Disney+](#dsnp)     |
-|                       |                       | [WEB Tier 01](#web-tier-01)             | [HBO Max](#hmax)     |
-|                       |                       | [WEB Tier 02](#web-tier-02)             | [HBO](#hbo)          |
-|                       |                       | [WEB Tier 03](#web-tier-03)             | [Hulu](#hulu)        |
-|                       |                       | [WEB Scene](#web-scene)                 | [NLZiet](#nlz)       |
-|                       |                       |                                         | [Netflix](#nf)       |
-|                       |                       |                                         | [Paramount+](#pmtp)  |
-|                       |                       |                                         | [Peacock TV](#pcok)  |
-|                       |                       |                                         | [Quibi](#qibi)       |
-|                       |                       |                                         | [SHOWTIME](#sho)     |
-|                       |                       |                                         | [Stan](#stan)        |
-|                       |                       |                                         | [Videoland](#vdl)    |
-|                       |                       |                                         | [YouTube Red](#red)  |
-|                       |                       |                                         | [iTunes](#it)        |
-|                       |                       |                                         | [CANAL+](#canalplus) |
-|                       |                       |                                         | [SALTO](#salto)      |
-|                       |                       |                                         | [RTBF](#rtbf)        |
+| Series Versions       | Unwanted              | HQ Source Groups                        | Streaming Services    |
+| --------------------- | --------------------- | --------------------------------------- | --------------------- |
+| [Hybrid](#hybrid)     | [BR-DISK](#br-disk)   | [Remux Tier 01](#remux-tier-01)         | [Amazon](#amzn)       |
+| [Remaster](#remaster) | [LQ](#lq)             | [Remux Tier 02](#remux-tier-02)         | [Apple TV+](#atvp)    |
+|                       | [x265 (HD)](#x265-hd) | [HD Bluray Tier 01](#hd-bluray-tier-01) | [DC Universe](#dcu)   |
+|                       |                       | [HD Bluray Tier 02](#hd-bluray-tier-02) | [Disney+](#dsnp)      |
+|                       |                       | [WEB Tier 01](#web-tier-01)             | [HBO Max](#hmax)      |
+|                       |                       | [WEB Tier 02](#web-tier-02)             | [HBO](#hbo)           |
+|                       |                       | [WEB Tier 03](#web-tier-03)             | [Hulu](#hulu)         |
+|                       |                       | [WEB Scene](#web-scene)                 | [NLZiet](#nlz)        |
+|                       |                       |                                         | [Netflix](#nf)        |
+|                       |                       |                                         | [Paramount+](#pmtp)   |
+|                       |                       |                                         | [Peacock TV](#pcok)   |
+|                       |                       |                                         | [Quibi](#qibi)        |
+|                       |                       |                                         | [SHOWTIME](#sho)      |
+|                       |                       |                                         | [Stan](#stan)         |
+|                       |                       |                                         | [Videoland](#vdl)     |
+|                       |                       |                                         | [YouTube Red](#red)   |
+|                       |                       |                                         | [iTunes](#it)         |
+|                       |                       |                                         | [CANAL+](#canalplus)  |
+|                       |                       |                                         | [SALTO](#salto)       |
+|                       |                       |                                         | [RTBF](#rtbf)         |
+|                       |                       |                                         | [Comedy Central](#cc) |
 
 ------
 
@@ -1640,6 +1641,24 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/french-rtbf.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### CC
+
+<sub>CC = Comedy Central</sub>
+
+??? question "CC - [CLICK TO EXPAND]"
+
+    [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Comedy_Central){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/cc.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "77a7b25585c18af08f60b1547bb9b4fb",
+  "trash_regex": "https://regex101.com/r/A3TRwE/1",
+  "name": "CC",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Comedy Central",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(CC)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/cc.json
+++ b/docs/json/sonarr/cf/cc.json
@@ -1,5 +1,6 @@
 {
   "trash_id": "77a7b25585c18af08f60b1547bb9b4fb",
+  "trash_score": "75",
   "trash_regex": "https://regex101.com/r/A3TRwE/1",
   "name": "CC",
   "includeCustomFormatWhenRenaming": true,

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -42,7 +42,8 @@
         "/\\b(pmtp)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(vdl)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(nlz)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(stan)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(stan)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b(cc)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     }
   ],

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -18,3 +18,4 @@
     | [{{ sonarr['cf']['sho']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#sho)   | {{ sonarr['cf']['sho']['trash_score'] }}  | {{ sonarr['cf']['sho']['trash_id'] }}  |
     | [{{ sonarr['cf']['stan']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#stan) | {{ sonarr['cf']['stan']['trash_score'] }} | {{ sonarr['cf']['stan']['trash_id'] }} |
     | [{{ sonarr['cf']['vdl']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vdl)   | {{ sonarr['cf']['vdl']['trash_score'] }}  | {{ sonarr['cf']['vdl']['trash_id'] }}  |
+    | [{{ sonarr['cf']['cc']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cc)     | {{ sonarr['cf']['cc']['trash_score'] }}   | {{ sonarr['cf']['cc']['trash_id'] }}   |


### PR DESCRIPTION
# Pull request

**Purpose**
Comedy Central streaming service missing in Sonarr custom formats.

**Approach**
Added Comedy Central streaming service to the Sonarr custom formats.
Closes #1148 

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
