### PR TITLE
feat(radarr): add `TvR` to `Bad Dual Audio` CF

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -158,6 +158,15 @@
       }
     },
     {
+      "name": "TvR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-TvR)\\b"
+      }
+    },
+    {
       "name": "WTV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Prevent TvR releases from getting fetched, because first audio is always german despite not being labeled as such.

**Approach**
Add TvR to the Bad Dual Audio CF. 
Closes #1156 

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
