### PR TITLE
Move recyclarr property up a level

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,9 +11,9 @@
       "custom_formats": ["docs/json/sonarr/cf"],
       "qualities": ["docs/json/sonarr/quality-size"],
       "naming": ["docs/json/sonarr/naming"]
-    },
-    "recyclarr": {
-      "templates": "docs/recyclarr-configs"
     }
+  },
+  "recyclarr": {
+    "templates": "docs/recyclarr-configs"
   }
 }

--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -10,10 +10,10 @@
       "additionalProperties": false,
       "properties": {
         "radarr": { "$ref": "#/$defs/radarr" },
-        "sonarr": { "$ref": "#/$defs/sonarr" },
-        "recyclarr": { "$ref": "#/$defs/recyclarr" }
+        "sonarr": { "$ref": "#/$defs/sonarr" }
       }
-    }
+    },
+    "recyclarr": { "$ref": "#/$defs/recyclarr" }
   },
   "$defs": {
     "paths_object": {


### PR DESCRIPTION
The `recyclarr` property was under `json_paths` which isn't appropriate for a few reasons:

1. `json_paths` is expected to be for guide-only data (like custom formats).
2. The recyclarr path at the moment is to YAML files, not JSON files.

