### PR TITLE
feat(starr): rework of HDR metadata CFs

### DIFF
--- a/docs/json/radarr/cf/dv-fel.json
+++ b/docs/json/radarr/cf/dv-fel.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-fel.json
+++ b/docs/json/radarr/cf/dv-fel.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -11,25 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?)\\b)(?!.*\\b(HDR10(\\+|P(lus)?)))"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "e23edd2482476e595fb990b12e7c609c",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/pADWJD/8",
+  "trash_regex": "https://regex101.com/r/xIFQQR/1",
   "name": "DV HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "55d53828b9d81cbe20b02efd00aa0efd",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/Bc7NTL/2",
   "name": "DV HLG",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HLG)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HLG(\\b|\\d)))"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -10,25 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HLG)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -10,25 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(SDR)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "a3e19f8f627608af0211acd02bf89735",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/aJn0H8/1",
   "name": "DV SDR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [

--- a/docs/json/radarr/cf/dv-webdl.json
+++ b/docs/json/radarr/cf/dv-webdl.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "923b6abef9b17f937fab56cfcf89e1f1",
   "trash_score": "-10000",
+  "trash_regex": "https://regex101.com/r/Jqg9Jo/2",
   "name": "DV (WEBDL)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-webdl.json
+++ b/docs/json/radarr/cf/dv-webdl.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     },
     {
@@ -38,15 +38,6 @@
       "required": true,
       "fields": {
         "value": "\\b(Flights)\\b"
-      }
-    },
-    {
-      "name": "Not HDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR(\\b|\\d)"
       }
     },
     {

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -10,34 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "58d6a88f13e2db7f5059c41047876f00",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/h9VdrP/2",
   "name": "DV",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr-undefined.json
+++ b/docs/json/radarr/cf/hdr-undefined.json
@@ -55,7 +55,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(HLG)\\b"
+        "value": "\\b(HLG(\\b|\\d))"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "e61e28db95d22bedcadf030b8f156d96",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/Jy24ye/2",
   "name": "HDR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr.json
+++ b/docs/json/radarr/cf/hdr.json
@@ -10,61 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
+        "value": "^(?=.*\\b(HDR)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -10,61 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "dfb86d5941bc9075d6af23b09c2aeecd",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/EsT3YN/2",
   "name": "HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "b17886cb4158d9fea189859409975758",
   "trash_score": "901",
-  "trash_regex": "https://regex101.com/r/hCAQEO/4",
+  "trash_regex": "https://regex101.com/r/keKCbP/2",
   "name": "HDR10+ Boost",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -11,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "b974a6cd08c1066250f1f177d7aa1225",
   "trash_score": "600",
-  "trash_regex": "https://regex101.com/r/hCAQEO/4",
+  "trash_regex": "https://regex101.com/r/keKCbP/2",
   "name": "HDR10+",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -11,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -10,43 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
+        "value": "^(?=.*\\b(HLG)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(PQ)\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hlg.json
+++ b/docs/json/radarr/cf/hlg.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "9364dd386c9b4a1100dde8264690add7",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/gAoHQt/1",
   "name": "HLG",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HLG)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(PQ)\b)"
+        "value": "^(?=.*\\b(HLG(\\b|\\d)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/pq.json
+++ b/docs/json/radarr/cf/pq.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "08d6d8834ad9ec87b1dc7ec8148e7a1f",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/aaUkkW/2",
   "name": "PQ",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "(?=.*\\b(PQ)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\b)"
+        "value": "^(?=.*\\b(PQ)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))"
       }
     }
   ]

--- a/docs/json/radarr/cf/pq.json
+++ b/docs/json/radarr/cf/pq.json
@@ -10,52 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
+        "value": "(?=.*\\b(PQ)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG)\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/sdr.json
+++ b/docs/json/radarr/cf/sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\b(HDR(\\b|\\d))|\\b(DV|DoVi|Dolby[ .]?Vision)\\b|\\b(PQ)\\b|\\b(HLG(\\b|\\d))|\\b(FraMeSToR|HQMUX|SiCFoI)\\b"
       }
     },
     {
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bSDR\\b"
+        "value": "\\b(SDR)\\b"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-fel.json
+++ b/docs/json/sonarr/cf/dv-fel.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "7878c33f1963fefb3d6c8657d46c2f0a",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/pADWJD/8",
+  "trash_regex": "https://regex101.com/r/xIFQQR/1",
   "name": "DV HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,25 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?)\\b)(?!.*\\b(HDR10(\\+|P(lus)?)))"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-hlg.json
+++ b/docs/json/sonarr/cf/dv-hlg.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "1f733af03141f068a540eec352589a89",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/Bc7NTL/2",
   "name": "DV HLG",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,25 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HLG(\\b|\\d)))"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-sdr.json
+++ b/docs/json/sonarr/cf/dv-sdr.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "27954b0a80aab882522a88a4d9eae1cd",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/aJn0H8/1",
   "name": "DV SDR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,25 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(SDR)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-webdl.json
+++ b/docs/json/sonarr/cf/dv-webdl.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "9b27ab6498ec0f31a3353992e19434ca",
   "trash_score": "-10000",
+  "trash_regex": "https://regex101.com/r/Jqg9Jo/2",
   "name": "DV (WEBDL)",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {
@@ -38,15 +39,6 @@
       "required": true,
       "fields": {
         "value": "\\b(Flights)\\b"
-      }
-    },
-    {
-      "name": "Not HDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR(\\b|\\d)"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "6d0d8de7b57e35518ac0308b0ddf404e",
   "trash_score": "1500",
+  "trash_regex": "https://regex101.com/r/h9VdrP/2",
   "name": "DV",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,34 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not DV HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(DV[ .]SDR)\\b"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr-undefined.json
+++ b/docs/json/sonarr/cf/hdr-undefined.json
@@ -55,7 +55,7 @@
       "negate": true,
       "required": true,
       "fields": {
-        "value": "\\b(HLG)\\b"
+        "value": "\\b(HLG(\\b|\\d))"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr.json
+++ b/docs/json/sonarr/cf/hdr.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "3e2c4e748b64a1a1118e0ea3f4cf6875",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/Jy24ye/2",
   "name": "HDR",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
+        "value": "^(?=.*\\b(HDR)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "3497799d29a085e2ac2df9d468413c94",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/EsT3YN/2",
   "name": "HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/hdr10plus-boost.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "0dad0a507451acddd754fe6dc3a7f5e7",
   "trash_score": "901",
-  "trash_regex": "https://regex101.com/r/hCAQEO/4",
+  "trash_regex": "https://regex101.com/r/keKCbP/2",
   "name": "HDR10+ Boost",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr10plus.json
+++ b/docs/json/sonarr/cf/hdr10plus.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "a3d82cbef5039f8d295478d28a887159",
   "trash_score": "600",
-  "trash_regex": "https://regex101.com/r/hCAQEO/4",
+  "trash_regex": "https://regex101.com/r/keKCbP/2",
   "name": "HDR10+",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,61 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(HDR(10)?(?!\\+))\\b)(?=.*\\b(DV|DoVi)\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
+        "value": "^(?=.*\\b(HDR10(\\+|P(lus)?)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hlg.json
+++ b/docs/json/sonarr/cf/hlg.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "17e889ce13117940092308f48b48b45b",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/gAoHQt/1",
   "name": "HLG",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,43 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not PQ",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(PQ)\\b"
+        "value": "^(?=.*\\b(HLG(\\b|\\d)))(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/pq.json
+++ b/docs/json/sonarr/cf/pq.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "2a7e3be05d3861d6df7171ec74cad727",
   "trash_score": "500",
+  "trash_regex": "https://regex101.com/r/aaUkkW/2",
   "name": "PQ",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -10,52 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(PQ)\\b"
-      }
-    },
-    {
-      "name": "Not DV",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(dv|dovi|dolby[ .]?vision)\\b"
-      }
-    },
-    {
-      "name": "Not HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\b[^+|Plus])"
-      }
-    },
-    {
-      "name": "Not HDR10+",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bHDR10(\\+|P(lus)?\\b)"
-      }
-    },
-    {
-      "name": "Not HLG",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\b(HLG)\\b"
-      }
-    },
-    {
-      "name": "Not SDR",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "\\bSDR(\\b|\\d)"
+        "value": "^(?=.*\\b(PQ)\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))"
       }
     }
   ]

--- a/docs/json/sonarr/cf/sdr.json
+++ b/docs/json/sonarr/cf/sdr.json
@@ -19,7 +19,7 @@
       "negate": true,
       "required": false,
       "fields": {
-        "value": "\\bHDR(\\b|\\d)|\\b(dv|dovi|dolby[ .]?vision)\\b|\\b(FraMeSToR|HQMUX|SICFoI)\\b|\\b(PQ)\\b|\\bHLG(\\b|\\d)"
+        "value": "\\b(HDR(\\b|\\d))|\\b(DV|DoVi|Dolby[ .]?Vision)\\b|\\b(PQ)\\b|\\b(HLG(\\b|\\d))|\\b(FraMeSToR|HQMUX|SiCFoI)\\b"
       }
     },
     {
@@ -28,7 +28,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\bSDR\\b"
+        "value": "\\b(SDR)\\b"
       }
     }
   ]

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,13 @@
+# 2023-02-18 21:45
+**[New]**
+- [Radarr] New CF `Upscaled` - A custom format that matches the most commonly used terms in upscaled releases.
+
+**[Updated]**
+- [Starr] Rewrote almost all the regex for the HDR metadata CFs to be oneliners, to prevent false matches from happening.
+
+**[Fixed]**
+- None
+
 # 2023-02-17 22:40
 **[New]**
 - None


### PR DESCRIPTION
# Pull request

**Purpose**
Rework the HDR metadata CFs, to prevent false matches from happening.

**Approach**
Rewrote almost all the regex for the HDR metadata CFs to be oneliners, to prevent false matches from happening.

**Requirements**
Check all boxes as they are completed

- [x] Change regex used in the Radarr CFs
- [x] Change regex used in the Sonarr CFs
- [x] Add regex example links

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
