### PR TITLE
fix(starr): fix mistakes in HDR metadata CFs

### DIFF
--- a/docs/json/radarr/cf/dv-fel.json
+++ b/docs/json/radarr/cf/dv-fel.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "\\b(DV|DoVi|Dolby[ .]?Vision)\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "58d6a88f13e2db7f5059c41047876f00",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/h9VdrP/2",
+  "trash_regex": "https://regex101.com/r/w1PRcu/1",
   "name": "DV",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10\\]?[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "dfb86d5941bc9075d6af23b09c2aeecd",
   "trash_score": "500",
-  "trash_regex": "https://regex101.com/r/EsT3YN/2",
+  "trash_regex": "https://regex101.com/r/9144Ol/1",
   "name": "HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR10\\]?[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/dv-fel.json
+++ b/docs/json/sonarr/cf/dv-fel.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(\\b|\\d)))(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "\\b(DV|DoVi|Dolby[ .]?Vision)\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "6d0d8de7b57e35518ac0308b0ddf404e",
   "trash_score": "1500",
-  "trash_regex": "https://regex101.com/r/h9VdrP/2",
+  "trash_regex": "https://regex101.com/r/w1PRcu/1",
   "name": "DV",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(HDR(10\\]?[^+P])?)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "3497799d29a085e2ac2df9d468413c94",
   "trash_score": "500",
-  "trash_regex": "https://regex101.com/r/EsT3YN/2",
+  "trash_regex": "https://regex101.com/r/9144Ol/1",
   "name": "HDR10",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(HDR10[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
+        "value": "^(?=.*\\b(HDR10\\]?[^+P])\\b)(?!.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?!.*\\b(SDR)\\b)(?!.*\\b(HLG(\\b|\\d)))(?!.*\\b(PQ)\\b)"
       }
     }
   ]

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,13 @@
+# 2023-02-19 13:30
+**[New]**
+- None
+
+**[Updated]**
+- None
+
+**[Fixed]**
+- [Starr] Fix mistakes in changes to the HDR metadata CFs - Change some regex to correctly match `DV`, `HDR10` and `DV (FEL)`.
+
 # 2023-02-18 21:45
 **[New]**
 - [Radarr] New CF `Upscaled` - A custom format that matches the most commonly used terms in upscaled releases.


### PR DESCRIPTION
# Pull request

**Purpose**
Fix mistakes in changes to the HDR metadata CFs that where merged with #1171.

**Approach**
Change some regex to correctly match `DV`, `HDR10` and `DV (FEL)`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
