### PR TITLE
Trivial: remove extra separator at the bottom of TrueNAS-Core Guide

### DIFF
--- a/docs/Hardlinks/How-to-setup-for/TrueNAS-Core.md
+++ b/docs/Hardlinks/How-to-setup-for/TrueNAS-Core.md
@@ -132,7 +132,5 @@ Now that you have a `data` folder, you can follow the normal folder structure re
 
 These subfolders you need to create yourself using your preferred method. Set your permissions accordingly as well. If you use ACLs on the datasets you can replicate the usual 775/664 (UMASK 002) or 755/644 (UMASK 022) recommendation, but this guide only covers the use of basic permissions for mounting and expects the end user to fine-tune permissions via chmod, chown, and uid/gid/umask settings on the applications that will be utilizing the share.
 
-------
-
 {! include-markdown "../../../includes/support.md" !}
 <!-- --8<-- "includes/support.md" -->


### PR DESCRIPTION
Trivial: remove extra separator at the bottom since the support include already contains it

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
