### PR TITLE
Fixes to anime recyclarr configs

### DIFF
--- a/docs/recyclarr-configs/radarr/anime-radarr.yml
+++ b/docs/recyclarr-configs/radarr/anime-radarr.yml
@@ -24,23 +24,24 @@ radarr:
           - 9edaeee9ea3bcd585da9b7c0ac3fc54f # Anime Web Tier 04 (Official Subs)
           - 22d953bbe897857b517928f3652b8dd3 # Anime Web Tier 05 (FanSubs)
           - a786fbc0eae05afe3bb51aee3c83a9d4 # Anime Web Tier 06 (FanSubs)
-          - 06b6542a47037d1e33b15aa3677c2365 # Anime Raws
           - b0fdc5897f68c9a68c70c25169f77447 # Anime LQ Groups
-          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
           - c259005cbaeb5ab44c06eddb4751e70c # v0
           - 5f400539421b8fcf71d51e6384434573 # v1
           - 3df5e6dfef4b09bb6002f732bed5b774 # v2
           - db92c27ba606996b146b57fbe6d09186 # v3
           - d4e5e842fad129a3c097bdb2d20d31a0 # v4
-          - a5d148168c4506b55cf53984107c396e # 10bit
-          - b23eae459cc960816f2d6ba84af45055 # Dubs Only
-          - 9172b2f683f6223e3a1846427b417a3d # VOSTFR
+          
           # Anime Streaming Services
           - 60f6d50cbd3cfc3e9a8c00e3a30c3114 # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
             reset_unmatched_scores: true
-      # Adjustable scoring section
+      # Custom Scoring
+      - trash_ids:
+          - 9172b2f683f6223e3a1846427b417a3d # VOSTFR
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000
       - trash_ids:
           - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
         quality_profiles:
@@ -51,6 +52,7 @@ radarr:
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 1000 # required as this differs from the standard scoring
+      # Adjustable scoring section
       - trash_ids:
           - 4a3b087eea2ce012fcc1ce319259a3be # Anime Dual Audio
         quality_profiles:
@@ -61,3 +63,18 @@ radarr:
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 0 # adjust as desired
+      - trash_ids:
+          - a5d148168c4506b55cf53984107c396e # 10bit
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: 0 # adjust as desired
+      - trash_ids:
+          - 06b6542a47037d1e33b15aa3677c2365 # Anime Raws
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000 # adjust as desired
+      - trash_ids:
+          - b23eae459cc960816f2d6ba84af45055 # Dubs Only
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000 # adjust as desired

--- a/docs/recyclarr-configs/radarr/anime-radarr.yml
+++ b/docs/recyclarr-configs/radarr/anime-radarr.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-anime: # A custom name used to identify this particular instance.
+  radarr-anime:  # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,71 +10,71 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Anime CF/Scoring
-          - fb3ccc5d5cc8f77c9055d4cb4561dded # Anime BD Tier 01 (Top SeaDex Muxers)
-          - 66926c8fa9312bc74ab71bf69aae4f4a # Anime BD Tier 02 (SeaDex Muxers)
-          - fa857662bad28d5ff21a6e611869a0ff # Anime BD Tier 03 (SeaDex Muxers)
-          - f262f1299d99b1a2263375e8fa2ddbb3 # Anime BD Tier 04 (SeaDex Muxers)
-          - ca864ed93c7b431150cc6748dc34875d # Anime BD Tier 05 (Remuxes)
-          - 9dce189b960fddf47891b7484ee886ca # Anime BD Tier 06 (FanSubs)
-          - 1ef101b3a82646b40e0cab7fc92cd896 # Anime BD Tier 07 (P2P/Scene)
-          - 6115ccd6640b978234cc47f2c1f2cadc # Anime BD Tier 08 (Mini Encodes)
-          - 8167cffba4febfb9a6988ef24f274e7e # Anime Web Tier 01 (Muxers)
-          - 8526c54e36b4962d340fce52ef030e76 # Anime Web Tier 02 (Top FanSubs)
-          - de41e72708d2c856fa261094c85e965d # Anime Web Tier 03 (Official Subs)
-          - 9edaeee9ea3bcd585da9b7c0ac3fc54f # Anime Web Tier 04 (Official Subs)
-          - 22d953bbe897857b517928f3652b8dd3 # Anime Web Tier 05 (FanSubs)
-          - a786fbc0eae05afe3bb51aee3c83a9d4 # Anime Web Tier 06 (FanSubs)
-          - b0fdc5897f68c9a68c70c25169f77447 # Anime LQ Groups
-          - c259005cbaeb5ab44c06eddb4751e70c # v0
-          - 5f400539421b8fcf71d51e6384434573 # v1
-          - 3df5e6dfef4b09bb6002f732bed5b774 # v2
-          - db92c27ba606996b146b57fbe6d09186 # v3
-          - d4e5e842fad129a3c097bdb2d20d31a0 # v4
-          
+          - fb3ccc5d5cc8f77c9055d4cb4561dded  # Anime BD Tier 01 (Top SeaDex Muxers)
+          - 66926c8fa9312bc74ab71bf69aae4f4a  # Anime BD Tier 02 (SeaDex Muxers)
+          - fa857662bad28d5ff21a6e611869a0ff  # Anime BD Tier 03 (SeaDex Muxers)
+          - f262f1299d99b1a2263375e8fa2ddbb3  # Anime BD Tier 04 (SeaDex Muxers)
+          - ca864ed93c7b431150cc6748dc34875d  # Anime BD Tier 05 (Remuxes)
+          - 9dce189b960fddf47891b7484ee886ca  # Anime BD Tier 06 (FanSubs)
+          - 1ef101b3a82646b40e0cab7fc92cd896  # Anime BD Tier 07 (P2P/Scene)
+          - 6115ccd6640b978234cc47f2c1f2cadc  # Anime BD Tier 08 (Mini Encodes)
+          - 8167cffba4febfb9a6988ef24f274e7e  # Anime Web Tier 01 (Muxers)
+          - 8526c54e36b4962d340fce52ef030e76  # Anime Web Tier 02 (Top FanSubs)
+          - de41e72708d2c856fa261094c85e965d  # Anime Web Tier 03 (Official Subs)
+          - 9edaeee9ea3bcd585da9b7c0ac3fc54f  # Anime Web Tier 04 (Official Subs)
+          - 22d953bbe897857b517928f3652b8dd3  # Anime Web Tier 05 (FanSubs)
+          - a786fbc0eae05afe3bb51aee3c83a9d4  # Anime Web Tier 06 (FanSubs)
+          - b0fdc5897f68c9a68c70c25169f77447  # Anime LQ Groups
+          - c259005cbaeb5ab44c06eddb4751e70c  # v0
+          - 5f400539421b8fcf71d51e6384434573  # v1
+          - 3df5e6dfef4b09bb6002f732bed5b774  # v2
+          - db92c27ba606996b146b57fbe6d09186  # v3
+          - d4e5e842fad129a3c097bdb2d20d31a0  # v4
           # Anime Streaming Services
-          - 60f6d50cbd3cfc3e9a8c00e3a30c3114 # VRV
+          - 60f6d50cbd3cfc3e9a8c00e3a30c3114  # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
             reset_unmatched_scores: true
       # Custom Scoring
+      # Anime CF/Scoring
       - trash_ids:
-          - 9172b2f683f6223e3a1846427b417a3d # VOSTFR
+          - 9172b2f683f6223e3a1846427b417a3d  # VOSTFR
         quality_profiles:
           - name: Remux-1080p - Anime
             score: -10000
       - trash_ids:
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 1050 # required as this differs from the standard scoring
+            score: 1050  # required as this differs from the standard scoring
       - trash_ids:
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 1000 # required as this differs from the standard scoring
+            score: 1000  # required as this differs from the standard scoring
       # Adjustable scoring section
       - trash_ids:
-          - 4a3b087eea2ce012fcc1ce319259a3be # Anime Dual Audio
+          - 4a3b087eea2ce012fcc1ce319259a3be  # Anime Dual Audio
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # adjust as desired
+            score: 0  # adjust as desired
       - trash_ids:
-          - 064af5f084a0a24458cc8ecd3220f93f # Uncensored
+          - 064af5f084a0a24458cc8ecd3220f93f  # Uncensored
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # adjust as desired
+            score: 0  # adjust as desired
       - trash_ids:
-          - a5d148168c4506b55cf53984107c396e # 10bit
+          - a5d148168c4506b55cf53984107c396e  # 10bit
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # adjust as desired
+            score: 0  # adjust as desired
       - trash_ids:
-          - 06b6542a47037d1e33b15aa3677c2365 # Anime Raws
+          - 06b6542a47037d1e33b15aa3677c2365  # Anime Raws
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: -10000 # adjust as desired
+            score: -10000  # adjust as desired
       - trash_ids:
-          - b23eae459cc960816f2d6ba84af45055 # Dubs Only
+          - b23eae459cc960816f2d6ba84af45055  # Dubs Only
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: -10000 # adjust as desired
+            score: -10000  # adjust as desired

--- a/docs/recyclarr-configs/radarr/hd-bluray-web.yml
+++ b/docs/recyclarr-configs/radarr/hd-bluray-web.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr:  # A custom name used to identify this particular instance.
+  radarr:   # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,47 +10,47 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
-          - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
+          - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: HD Bluray + WEB
             reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: HD Bluray + WEB
             score: 0

--- a/docs/recyclarr-configs/radarr/remux-web-1080p.yml
+++ b/docs/recyclarr-configs/radarr/remux-web-1080p.yml
@@ -10,62 +10,62 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio - Uncomment the next section if you are using the Advanced Audio Formats
-          # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          # - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          # - 3cafb66171b47f226146a0770576870f # TrueHD
-          # - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          # - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          # - e7c2fcae07cbada050a0af3357491d7b # PCM
-          # - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          # - 185f1dd7264c4562b9022d963ac37424 # DD+
-          # - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          # - 240770601cc226190c367ef59aba7463 # AAC
-          # - c2998bd0d90ed5621d8df281e839436e # DD
+          # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          # - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          # - 3cafb66171b47f226146a0770576870f  # TrueHD
+          # - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          # - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          # - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          # - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          # - 185f1dd7264c4562b9022d963ac37424  # DD+
+          # - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          # - 240770601cc226190c367ef59aba7463  # AAC
+          # - c2998bd0d90ed5621d8df281e839436e  # DD
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux + WEB 1080p
             reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Remux + WEB 1080p
             score: 0

--- a/docs/recyclarr-configs/radarr/remux-web-2160p.yml
+++ b/docs/recyclarr-configs/radarr/remux-web-2160p.yml
@@ -10,77 +10,77 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio - Uncomment the next section if you are using the Advanced Audio Formats
-          # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          # - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          # - 3cafb66171b47f226146a0770576870f # TrueHD
-          # - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          # - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          # - e7c2fcae07cbada050a0af3357491d7b # PCM
-          # - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          # - 185f1dd7264c4562b9022d963ac37424 # DD+
-          # - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          # - 240770601cc226190c367ef59aba7463 # AAC
-          # - c2998bd0d90ed5621d8df281e839436e # DD
+          # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          # - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          # - 3cafb66171b47f226146a0770576870f  # TrueHD
+          # - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          # - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          # - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          # - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          # - 185f1dd7264c4562b9022d963ac37424  # DD+
+          # - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          # - 240770601cc226190c367ef59aba7463  # AAC
+          # - c2998bd0d90ed5621d8df281e839436e  # DD
           # All HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # DV (WEBDL) - The next line must be uncommented if any devices using your library DO NOT support Dolby Vision
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+          # - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux + WEB 2160p
             reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Remux + WEB 2160p
             score: 0

--- a/docs/recyclarr-configs/radarr/sqp-1.yml
+++ b/docs/recyclarr-configs/radarr/sqp-1.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-sqp-streaming: # A custom name used to identify this particular instance.
+  radarr-sqp-streaming:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,92 +10,92 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
           # Uncomment the next line(s) if you prefer IMAX/IMAX Enhanced to BHDStudio
-          # - eecf3a857724171f968a66cb5719e152 # IMAX
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - eecf3a857724171f968a66cb5719e152  # IMAX
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 5153ec7413d9dae44e24275589b5e944 # BHDStudio
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 5153ec7413d9dae44e24275589b5e944  # BHDStudio
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - dc98083864ea246d05a42df0d05f81cc # x265 (HD)
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
           # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
-          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          # - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+          # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+          # - f537cf427b64c38c8e36298f657e4828  # Scene
+          # - 0a3f082873eb454bde444150b70253cc  # Extras
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           # Resolution
-          - b2be17d608fc88818940cd1833b0b24c # 720p
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
+          - b2be17d608fc88818940cd1833b0b24c  # 720p
+          - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Bluray|WEB-1080p
             reset_unmatched_scores: true
       # Custom Scoring
       # HQ Release Groups - Optional - Uncomment the next section (10 lines) to enable other Bluray Encodes (less or not streaming optimized)
       # - trash_ids:
-          # - ed27ebfef2f323e964fb1f61391bcb35 # HD Bluray Tier 01
+          # - ed27ebfef2f323e964fb1f61391bcb35  # HD Bluray Tier 01
         # quality_profiles:
           # - name: Bluray|WEB-1080p
             # score: 1100
       # - trash_ids:
-          # - c20c8647f2746a1f4c4262b0fbbeeeae # HD Bluray Tier 02
+          # - c20c8647f2746a1f4c4262b0fbbeeeae  # HD Bluray Tier 02
         # quality_profiles:
           # - name: Bluray|WEB-1080p
             # score: 1050
       # --HQ Release Groups section ends--
       - trash_ids:
           # Audio
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+          - c2998bd0d90ed5621d8df281e839436e  # DD
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Bluray|WEB-1080p
             score: 0
       - trash_ids:
           # Audio
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
         quality_profiles:
           - name: Bluray|WEB-1080p
             score: -10000

--- a/docs/recyclarr-configs/radarr/sqp-2.yml
+++ b/docs/recyclarr-configs/radarr/sqp-2.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-sqp-uhd: # A custom name used to identify this particular instance.
+  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,76 +10,76 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+          - c2998bd0d90ed5621d8df281e839436e  # DD
           # HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
           # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
-          - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
-          - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - 4d74ac4c4db0b64bff6ce0cffef99bf0  # UHD Bluray Tier 01
+          - a58f517a70193f8e578056642178419d  # UHD Bluray Tier 02
+          - e71939fae578037e7aed3ee219bbe7c1  # UHD Bluray Tier 03
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
-          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          # - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+          # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+          # - f537cf427b64c38c8e36298f657e4828  # Scene
+          # - 0a3f082873eb454bde444150b70253cc  # Extras
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           # Resolution
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+          - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
+          - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
             reset_unmatched_scores: true
@@ -87,29 +87,29 @@ radarr:
       - trash_ids:
           # DV (WEBDL)
           # If you and all of your users have a setup that fully supports DV, then uncomment the score line below
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
-            # score: 0 # overrides default of -10000
+            # score: 0  # overrides default of -10000
       # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
-          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+          - 2899d84dc9372de3408e6d8cc18e9666  # x264
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
             score: -10000
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
             score: 0

--- a/docs/recyclarr-configs/radarr/sqp-3.yml
+++ b/docs/recyclarr-configs/radarr/sqp-3.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-sqp-uhd: # A custom name used to identify this particular instance.
+  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,73 +10,73 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+          - c2998bd0d90ed5621d8df281e839436e  # DD
           # HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - f700d29429c023a5734505e77daeaea7 # DV (FEL)
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - f700d29429c023a5734505e77daeaea7  # DV (FEL)
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
           # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
-          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          # - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+          # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+          # - f537cf427b64c38c8e36298f657e4828  # Scene
+          # - 0a3f082873eb454bde444150b70253cc  # Extras
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           # Resolution
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+          - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
+          - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux|IMAX-E|2160p
             reset_unmatched_scores: true
@@ -84,29 +84,29 @@ radarr:
       - trash_ids:
           # DV (WEBDL)
           # If you and all of your users have a setup that fully supports DV, then uncomment the score line below
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
         quality_profiles:
           - name: Remux|IMAX-E|2160p
-            # score: 0 # overrides default of -10000
+            # score: 0  # overrides default of -10000
       # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
-          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+          - 2899d84dc9372de3408e6d8cc18e9666  # x264
         quality_profiles:
           - name: Remux|IMAX-E|2160p
             score: -10000
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Remux|IMAX-E|2160p
             score: 0

--- a/docs/recyclarr-configs/radarr/sqp-4.yml
+++ b/docs/recyclarr-configs/radarr/sqp-4.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-sqp-uhd: # A custom name used to identify this particular instance.
+  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,72 +10,72 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+          - c2998bd0d90ed5621d8df281e839436e  # DD
           # HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
           # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
-          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          # - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+          # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+          # - f537cf427b64c38c8e36298f657e4828  # Scene
+          # - 0a3f082873eb454bde444150b70253cc  # Extras
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           # Resolution
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+          - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
+          - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
             reset_unmatched_scores: true
@@ -83,29 +83,29 @@ radarr:
       - trash_ids:
           # DV (WEBDL)
           # If you and all of your users have a setup that fully supports DV, then uncomment the score line below
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
-            # score: 0 # overrides default of -10000
+            # score: 0  # overrides default of -10000
       # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
-          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+          - 2899d84dc9372de3408e6d8cc18e9666  # x264
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
             score: -10000
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
             score: 0

--- a/docs/recyclarr-configs/radarr/sqp-5.yml
+++ b/docs/recyclarr-configs/radarr/sqp-5.yml
@@ -1,5 +1,5 @@
 radarr:
-  radarr-sqp-uhd: # A custom name used to identify this particular instance.
+  radarr-sqp-uhd:  # A custom name used to identify this particular instance.
     base_url: [radarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -10,75 +10,75 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio
-          - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          - 3cafb66171b47f226146a0770576870f # TrueHD
-          - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          - e7c2fcae07cbada050a0af3357491d7b # PCM
-          - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          - 185f1dd7264c4562b9022d963ac37424 # DD+
-          - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          - 240770601cc226190c367ef59aba7463 # AAC
-          - c2998bd0d90ed5621d8df281e839436e # DD
+          - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          - 3cafb66171b47f226146a0770576870f  # TrueHD
+          - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          - 185f1dd7264c4562b9022d963ac37424  # DD+
+          - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          - 240770601cc226190c367ef59aba7463  # AAC
+          - c2998bd0d90ed5621d8df281e839436e  # DD
           # HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
           # Uncomment the next line if you prefer IMAX Enhanced releases
-          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          # - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 3a3ff47579026e76d6504ebea39390de # Remux Tier 01
-          - 9f98181fe5a3fbeb0cc29340da2a468a # Remux Tier 02
-          - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
-          - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
-          - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 3a3ff47579026e76d6504ebea39390de  # Remux Tier 01
+          - 9f98181fe5a3fbeb0cc29340da2a468a  # Remux Tier 02
+          - 4d74ac4c4db0b64bff6ce0cffef99bf0  # UHD Bluray Tier 01
+          - a58f517a70193f8e578056642178419d  # UHD Bluray Tier 02
+          - e71939fae578037e7aed3ee219bbe7c1  # UHD Bluray Tier 03
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 839bea857ed2c0a8e084f3cbdbd65ecb # x265 (no HDR/DV)
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Optional
           # Uncomment any of the following optional custom formats if you want them to be added to the quality profile
-          # - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-          # - 90cedc1fea7ea5d11298bebd3d1d3223 # EVO (no WEBDL)
-          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-          # - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-          # - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-          # - f537cf427b64c38c8e36298f657e4828 # Scene
-          # - 0a3f082873eb454bde444150b70253cc # Extras
-          # - bfd8eb01832d646a0a89c4deb46f8564 # Upscaled
+          # - b6832f586342ef70d9c128d40c07b872  # Bad Dual Groups
+          # - 90cedc1fea7ea5d11298bebd3d1d3223  # EVO (no WEBDL)
+          # - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5  # No-RlsGroup
+          # - 7357cf5161efbf8c4d5d0c30b4815ee2  # Obfuscated
+          # - 5c44f52a8714fdd79bb4d98e2673be1f  # Retags
+          # - f537cf427b64c38c8e36298f657e4828  # Scene
+          # - 0a3f082873eb454bde444150b70253cc  # Extras
+          # - bfd8eb01832d646a0a89c4deb46f8564  # Upscaled
           # Resolution
-          - 820b09bb9acbfde9c35c71e0e565dad8 # 1080p
-          - fb392fb0d61a010ae38e49ceaa24a1ef # 2160p
+          - 820b09bb9acbfde9c35c71e0e565dad8  # 1080p
+          - fb392fb0d61a010ae38e49ceaa24a1ef  # 2160p
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
             reset_unmatched_scores: true
@@ -86,29 +86,29 @@ radarr:
       - trash_ids:
           # DV (WEBDL)
           # If you and all of your users have a setup that fully supports DV, then uncomment the score line below
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
-            # score: 0 # overrides default of -10000
+            # score: 0  # overrides default of -10000
       # If you are only running one Radarr instance, you can comment out the next six lines so you will get the HD release if there is no UHD version
       - trash_ids:
           # Misc
-          - 2899d84dc9372de3408e6d8cc18e9666 # x264
+          - 2899d84dc9372de3408e6d8cc18e9666  # x264
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
             score: -10000
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
             score: 0

--- a/docs/recyclarr-configs/radarr/uhd-bluray-web.yml
+++ b/docs/recyclarr-configs/radarr/uhd-bluray-web.yml
@@ -10,78 +10,78 @@ radarr:
       # Scores from TRaSH json
       - trash_ids:
           # Audio - Uncomment the next section if you are using the Advanced Audio Formats
-          # - 496f355514737f7d83bf7aa4d24f8169 # TrueHD Atmos
-          # - 2f22d89048b01681dde8afe203bf2e95 # DTS X
-          # - 417804f7f2c4308c1f4c5d380d4c4475 # ATMOS (undefined)
-          # - 1af239278386be2919e1bcee0bde047e # DD+ ATMOS
-          # - 3cafb66171b47f226146a0770576870f # TrueHD
-          # - dcf3ec6938fa32445f590a4da84256cd # DTS-HD MA
-          # - a570d4a0e56a2874b64e5bfa55202a1b # FLAC
-          # - e7c2fcae07cbada050a0af3357491d7b # PCM
-          # - 8e109e50e0a0b83a5098b056e13bf6db # DTS-HD HRA
-          # - 185f1dd7264c4562b9022d963ac37424 # DD+
-          # - f9f847ac70a0af62ea4a08280b859636 # DTS-ES
-          # - 1c1a4c5e823891c75bc50380a6866f73 # DTS
-          # - 240770601cc226190c367ef59aba7463 # AAC
-          # - c2998bd0d90ed5621d8df281e839436e # DD
+          # - 496f355514737f7d83bf7aa4d24f8169  # TrueHD Atmos
+          # - 2f22d89048b01681dde8afe203bf2e95  # DTS X
+          # - 417804f7f2c4308c1f4c5d380d4c4475  # ATMOS (undefined)
+          # - 1af239278386be2919e1bcee0bde047e  # DD+ ATMOS
+          # - 3cafb66171b47f226146a0770576870f  # TrueHD
+          # - dcf3ec6938fa32445f590a4da84256cd  # DTS-HD MA
+          # - a570d4a0e56a2874b64e5bfa55202a1b  # FLAC
+          # - e7c2fcae07cbada050a0af3357491d7b  # PCM
+          # - 8e109e50e0a0b83a5098b056e13bf6db  # DTS-HD HRA
+          # - 185f1dd7264c4562b9022d963ac37424  # DD+
+          # - f9f847ac70a0af62ea4a08280b859636  # DTS-ES
+          # - 1c1a4c5e823891c75bc50380a6866f73  # DTS
+          # - 240770601cc226190c367ef59aba7463  # AAC
+          # - c2998bd0d90ed5621d8df281e839436e  # DD
           # All HDR Formats
-          - e23edd2482476e595fb990b12e7c609c # DV HDR10
-          - 58d6a88f13e2db7f5059c41047876f00 # DV
-          - 55d53828b9d81cbe20b02efd00aa0efd # DV HLG
-          - a3e19f8f627608af0211acd02bf89735 # DV SDR
-          - b974a6cd08c1066250f1f177d7aa1225 # HDR10+
-          - dfb86d5941bc9075d6af23b09c2aeecd # HDR10
-          - e61e28db95d22bedcadf030b8f156d96 # HDR
-          - 2a4d9069cc1fe3242ff9bdaebed239bb # HDR (undefined)
-          - 08d6d8834ad9ec87b1dc7ec8148e7a1f # PQ
-          - 9364dd386c9b4a1100dde8264690add7 # HLG
+          - e23edd2482476e595fb990b12e7c609c  # DV HDR10
+          - 58d6a88f13e2db7f5059c41047876f00  # DV
+          - 55d53828b9d81cbe20b02efd00aa0efd  # DV HLG
+          - a3e19f8f627608af0211acd02bf89735  # DV SDR
+          - b974a6cd08c1066250f1f177d7aa1225  # HDR10+
+          - dfb86d5941bc9075d6af23b09c2aeecd  # HDR10
+          - e61e28db95d22bedcadf030b8f156d96  # HDR
+          - 2a4d9069cc1fe3242ff9bdaebed239bb  # HDR (undefined)
+          - 08d6d8834ad9ec87b1dc7ec8148e7a1f  # PQ
+          - 9364dd386c9b4a1100dde8264690add7  # HLG
           # DV (WEBDL) - The next line must be uncommented if any devices using your library DO NOT support Dolby Vision
-          - 923b6abef9b17f937fab56cfcf89e1f1 # DV (WEBDL)
+          - 923b6abef9b17f937fab56cfcf89e1f1  # DV (WEBDL)
           # HDR10Plus Boost - Uncomment the next line if any of your devices DO support HDR10+
-          # - b17886cb4158d9fea189859409975758 # HDR10Plus Boost
+          # - b17886cb4158d9fea189859409975758  # HDR10Plus Boost
           # Movie Versions
-          - 0f12c086e289cf966fa5948eac571f44 # Hybrid
-          - 570bc9ebecd92723d2d21500f4be314c # Remaster
-          - eca37840c13c6ef2dd0262b141a5482f # 4K Remaster
-          - e0c07d59beb37348e975a930d5e50319 # Criterion Collection
-          - 9d27d9d2181838f76dee150882bdc58c # Masters of Cinema
-          - 957d0f44b592285f26449575e8b1167e # Special Edition
-          - eecf3a857724171f968a66cb5719e152 # IMAX
-          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+          - 0f12c086e289cf966fa5948eac571f44  # Hybrid
+          - 570bc9ebecd92723d2d21500f4be314c  # Remaster
+          - eca37840c13c6ef2dd0262b141a5482f  # 4K Remaster
+          - e0c07d59beb37348e975a930d5e50319  # Criterion Collection
+          - 9d27d9d2181838f76dee150882bdc58c  # Masters of Cinema
+          - 957d0f44b592285f26449575e8b1167e  # Special Edition
+          - eecf3a857724171f968a66cb5719e152  # IMAX
+          - 9f6cbff8cfe4ebbc1bde14c7b7bec0de  # IMAX Enhanced
           # HQ Release Groups
-          - 4d74ac4c4db0b64bff6ce0cffef99bf0 # UHD Bluray Tier 01
-          - a58f517a70193f8e578056642178419d # UHD Bluray Tier 02
-          - e71939fae578037e7aed3ee219bbe7c1 # UHD Bluray Tier 03
-          - c20f169ef63c5f40c2def54abaf4438e # WEB Tier 01
-          - 403816d65392c79236dcb6dd591aeda4 # WEB Tier 02
-          - af94e0fe497124d1f9ce732069ec8c3b # WEB Tier 03
+          - 4d74ac4c4db0b64bff6ce0cffef99bf0  # UHD Bluray Tier 01
+          - a58f517a70193f8e578056642178419d  # UHD Bluray Tier 02
+          - e71939fae578037e7aed3ee219bbe7c1  # UHD Bluray Tier 03
+          - c20f169ef63c5f40c2def54abaf4438e  # WEB Tier 01
+          - 403816d65392c79236dcb6dd591aeda4  # WEB Tier 02
+          - af94e0fe497124d1f9ce732069ec8c3b  # WEB Tier 03
           # Misc
-          - e7718d7a3ce595f289bfee26adc178f5 # Repack/Proper
-          - ae43b294509409a6a13919dedd4764c4 # Repack2
+          - e7718d7a3ce595f289bfee26adc178f5  # Repack/Proper
+          - ae43b294509409a6a13919dedd4764c4  # Repack2
           # Unwanted
-          - ed38b889b31be83fda192888e2286d83 # BR-DISK
-          - 90a6f9a284dff5103f6346090e6280c8 # LQ
-          - b8cd450cbfa689c0259a01d9e29ba3d6 # 3D
-          - 9c38ebb7384dada637be8899efa68e6f # SDR
+          - ed38b889b31be83fda192888e2286d83  # BR-DISK
+          - 90a6f9a284dff5103f6346090e6280c8  # LQ
+          - b8cd450cbfa689c0259a01d9e29ba3d6  # 3D
+          - 9c38ebb7384dada637be8899efa68e6f  # SDR
           # Streaming Services
-          - cc5e51a9e85a6296ceefe097a77f12f4 # BCORE
-          - 2a6039655313bf5dab1e43523b62c374 # MA
+          - cc5e51a9e85a6296ceefe097a77f12f4  # BCORE
+          - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: UHD Bluray + WEB
             reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services
-          - b3b3a6ac74ecbd56bcdbefa4799fb9df # AMZN
-          - 40e9380490e748672c2522eaaeb692f7 # ATVP
-          - 84272245b2988854bfb76a16e60baea5 # DSNP
-          - 509e5f41146e278f9eab1ddaceb34515 # HBO
-          - 5763d1b0ce84aff3b21038eea8e9b8ad # HMAX
-          - 526d445d4c16214309f0fd2b3be18a89 # Hulu
-          - 170b1d363bd8516fbf3a3eb05d4faff6 # NF
-          - c9fd353f8f5f1baf56dc601c4cb29920 # PCOK
-          - e36a0ba1bc902b26ee40818a1d59b8bd # PMTP
-          - c2863d2a50c9acad1fb50e53ece60817 # STAN
+          - b3b3a6ac74ecbd56bcdbefa4799fb9df  # AMZN
+          - 40e9380490e748672c2522eaaeb692f7  # ATVP
+          - 84272245b2988854bfb76a16e60baea5  # DSNP
+          - 509e5f41146e278f9eab1ddaceb34515  # HBO
+          - 5763d1b0ce84aff3b21038eea8e9b8ad  # HMAX
+          - 526d445d4c16214309f0fd2b3be18a89  # Hulu
+          - 170b1d363bd8516fbf3a3eb05d4faff6  # NF
+          - c9fd353f8f5f1baf56dc601c4cb29920  # PCOK
+          - e36a0ba1bc902b26ee40818a1d59b8bd  # PMTP
+          - c2863d2a50c9acad1fb50e53ece60817  # STAN
         quality_profiles:
           - name: UHD Bluray + WEB
             score: 0

--- a/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
+++ b/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
@@ -1,6 +1,6 @@
 # This config file is for use with Sonarr V4 only
 sonarr:
-  sonarr: # A custom name used to identify this particular instance.
+  sonarr-anime: # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -25,31 +25,37 @@ sonarr:
           - 4fd5528a3a8024e6b49f9c67053ea5f3 # Anime Web Tier 04 (Official Subs)
           - 29c2a13d091144f63307e4a8ce963a39 # Anime Web Tier 05 (FanSubs)
           - dc262f88d74c651b12e9d90b39f6c753 # Anime Web Tier 06 (FanSubs)
-          - b4a1b3d705159cdca36d71e57ca86871 # Anime Raws
           - e3515e519f3b1360cbfc17651944354c # Anime LQ Groups
-          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
           - d2d7b8a9d39413da5f44054080e028a3 # v0
           - 273bd326df95955e1b6c26527d1df89b # v1
           - 228b8ee9aa0a609463efca874524a6b8 # v2
           - 0e5833d3af2cc5fa96a0c29cd4477feb # v3
           - 4fc15eeb8f2f9a749f918217d4234ad8 # v4
-          - b2550eb333d27b75833e25b8c2557b38 # 10bit
-          - 9c14d194486c4014d422adc64092d794 # Dubs Only
-          - 07a32f77690263bb9fda1842db7e273f # VOSTFR
           # Anime Streaming Services
           - d660701077794679fd59e8bdf4ce3a29 # AMZN
-          - 7dd31f3dee6d2ef8eeaa156e23c3857e # B-Global
-          - 4c67ff059210182b59cdd41697b8cb08 # Bilibili
           - 3e0b26604165f463f3e8e192261e7284 # CR
           - 89358767a60cc28783cdc3d0be9388a4 # DSNP
           - 1284d18e693de8efe0fe7d6b3e0b9170 # FUNi
-          - 570b03b3145a25011bf073274a407259 # HIDIVE
           - d34870697c9db575f17700212167be23 # NF
           - 44a8ee6403071dd7b8a3a8dd3fe8cb20 # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
             reset_unmatched_scores: true
-      # Adjustable scoring section
+      # Custom scoring
+      - trash_ids:
+          # Anime Streaming Services
+          - 7dd31f3dee6d2ef8eeaa156e23c3857e # B-Global
+          - 4c67ff059210182b59cdd41697b8cb08 # Bilibili
+          - 570b03b3145a25011bf073274a407259 # HIDIVE
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: 0
+      - trash_ids:
+          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
+          - 07a32f77690263bb9fda1842db7e273f # VOSTFR
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000
       - trash_ids:
           - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01
         quality_profiles:
@@ -65,13 +71,29 @@ sonarr:
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 350 # required as this differs from the standard scoring
+      # Adjustable scoring section
       - trash_ids:
           - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # adjust as desired
+            score: 0 # Adjust scoring as desired
       - trash_ids:
           - 026d5aadd1a6b4e550b134cb6c72b3ca # Uncensored
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # adjust as desired
+            score: 0 # Adjust scoring as desired
+      - trash_ids:
+          - b2550eb333d27b75833e25b8c2557b38 # 10bit
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: 0 # Adjust scoring as desired
+      - trash_ids:
+          - b4a1b3d705159cdca36d71e57ca86871 # Anime Raws
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000 # Adjust scoring as desired
+      - trash_ids:
+          - 9c14d194486c4014d422adc64092d794 # Dubs Only
+        quality_profiles:
+          - name: Remux-1080p - Anime
+            score: -10000 # Adjust scoring as desired

--- a/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
+++ b/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
@@ -1,6 +1,6 @@
 # This config file is for use with Sonarr V4 only
 sonarr:
-  sonarr-anime: # A custom name used to identify this particular instance.
+  sonarr-anime:  # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 
@@ -11,89 +11,90 @@ sonarr:
       # Scores from TRaSH json
       - trash_ids:
           # Anime CF/Scoring
-          - 949c16fe0a8147f50ba82cc2df9411c9 # Anime BD Tier 01 (Top SeaDex Muxers)
-          - ed7f1e315e000aef424a58517fa48727 # Anime BD Tier 02 (SeaDex Muxers)
-          - 096e406c92baa713da4a72d88030b815 # Anime BD Tier 03 (SeaDex Muxers)
-          - 30feba9da3030c5ed1e0f7d610bcadc4 # Anime BD Tier 04 (SeaDex Muxers)
-          - 545a76b14ddc349b8b185a6344e28b04 # Anime BD Tier 05 (Remuxes)
-          - 25d2afecab632b1582eaf03b63055f72 # Anime BD Tier 06 (FanSubs)
-          - 0329044e3d9137b08502a9f84a7e58db # Anime BD Tier 07 (P2P/Scene)
-          - c81bbfb47fed3d5a3ad027d077f889de # Anime BD Tier 08 (Mini Encodes)
-          - e0014372773c8f0e1bef8824f00c7dc4 # Anime Web Tier 01 (Muxers)
-          - 19180499de5ef2b84b6ec59aae444696 # Anime Web Tier 02 (Top FanSubs)
-          - c27f2ae6a4e82373b0f1da094e2489ad # Anime Web Tier 03 (Official Subs)
-          - 4fd5528a3a8024e6b49f9c67053ea5f3 # Anime Web Tier 04 (Official Subs)
-          - 29c2a13d091144f63307e4a8ce963a39 # Anime Web Tier 05 (FanSubs)
-          - dc262f88d74c651b12e9d90b39f6c753 # Anime Web Tier 06 (FanSubs)
-          - e3515e519f3b1360cbfc17651944354c # Anime LQ Groups
-          - d2d7b8a9d39413da5f44054080e028a3 # v0
-          - 273bd326df95955e1b6c26527d1df89b # v1
-          - 228b8ee9aa0a609463efca874524a6b8 # v2
-          - 0e5833d3af2cc5fa96a0c29cd4477feb # v3
-          - 4fc15eeb8f2f9a749f918217d4234ad8 # v4
+          - 949c16fe0a8147f50ba82cc2df9411c9  # Anime BD Tier 01 (Top SeaDex Muxers)
+          - ed7f1e315e000aef424a58517fa48727  # Anime BD Tier 02 (SeaDex Muxers)
+          - 096e406c92baa713da4a72d88030b815  # Anime BD Tier 03 (SeaDex Muxers)
+          - 30feba9da3030c5ed1e0f7d610bcadc4  # Anime BD Tier 04 (SeaDex Muxers)
+          - 545a76b14ddc349b8b185a6344e28b04  # Anime BD Tier 05 (Remuxes)
+          - 25d2afecab632b1582eaf03b63055f72  # Anime BD Tier 06 (FanSubs)
+          - 0329044e3d9137b08502a9f84a7e58db  # Anime BD Tier 07 (P2P/Scene)
+          - c81bbfb47fed3d5a3ad027d077f889de  # Anime BD Tier 08 (Mini Encodes)
+          - e0014372773c8f0e1bef8824f00c7dc4  # Anime Web Tier 01 (Muxers)
+          - 19180499de5ef2b84b6ec59aae444696  # Anime Web Tier 02 (Top FanSubs)
+          - c27f2ae6a4e82373b0f1da094e2489ad  # Anime Web Tier 03 (Official Subs)
+          - 4fd5528a3a8024e6b49f9c67053ea5f3  # Anime Web Tier 04 (Official Subs)
+          - 29c2a13d091144f63307e4a8ce963a39  # Anime Web Tier 05 (FanSubs)
+          - dc262f88d74c651b12e9d90b39f6c753  # Anime Web Tier 06 (FanSubs)
+          - e3515e519f3b1360cbfc17651944354c  # Anime LQ Groups
+          - d2d7b8a9d39413da5f44054080e028a3  # v0
+          - 273bd326df95955e1b6c26527d1df89b  # v1
+          - 228b8ee9aa0a609463efca874524a6b8  # v2
+          - 0e5833d3af2cc5fa96a0c29cd4477feb  # v3
+          - 4fc15eeb8f2f9a749f918217d4234ad8  # v4
           # Anime Streaming Services
-          - d660701077794679fd59e8bdf4ce3a29 # AMZN
-          - 3e0b26604165f463f3e8e192261e7284 # CR
-          - 89358767a60cc28783cdc3d0be9388a4 # DSNP
-          - 1284d18e693de8efe0fe7d6b3e0b9170 # FUNi
-          - d34870697c9db575f17700212167be23 # NF
-          - 44a8ee6403071dd7b8a3a8dd3fe8cb20 # VRV
+          - d660701077794679fd59e8bdf4ce3a29  # AMZN
+          - 3e0b26604165f463f3e8e192261e7284  # CR
+          - 89358767a60cc28783cdc3d0be9388a4  # DSNP
+          - 1284d18e693de8efe0fe7d6b3e0b9170  # FUNi
+          - d34870697c9db575f17700212167be23  # NF
+          - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
             reset_unmatched_scores: true
       # Custom scoring
       - trash_ids:
           # Anime Streaming Services
-          - 7dd31f3dee6d2ef8eeaa156e23c3857e # B-Global
-          - 4c67ff059210182b59cdd41697b8cb08 # Bilibili
-          - 570b03b3145a25011bf073274a407259 # HIDIVE
+          - 7dd31f3dee6d2ef8eeaa156e23c3857e  # B-Global
+          - 4c67ff059210182b59cdd41697b8cb08  # Bilibili
+          - 570b03b3145a25011bf073274a407259  # HIDIVE
         quality_profiles:
           - name: Remux-1080p - Anime
             score: 0
+      # Anime CF/Scoring
       - trash_ids:
-          - 15a05bc7c1a36e2b57fd628f8977e2fc # AV1
-          - 07a32f77690263bb9fda1842db7e273f # VOSTFR
+          - 15a05bc7c1a36e2b57fd628f8977e2fc  # AV1
+          - 07a32f77690263bb9fda1842db7e273f  # VOSTFR
         quality_profiles:
           - name: Remux-1080p - Anime
             score: -10000
       - trash_ids:
-          - e6258996055b9fbab7e9cb2f75819294 # WEB Tier 01
+          - e6258996055b9fbab7e9cb2f75819294  # WEB Tier 01
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 450 # required as this differs from the standard scoring
+            score: 450  # required as this differs from the standard scoring
       - trash_ids:
-          - 58790d4e2fdcd9733aa7ae68ba2bb503 # WEB Tier 02
+          - 58790d4e2fdcd9733aa7ae68ba2bb503  # WEB Tier 02
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 400 # required as this differs from the standard scoring
+            score: 400  # required as this differs from the standard scoring
       - trash_ids:
-          - d84935abd3f8556dcd51d4f27e22d0a6 # WEB Tier 03
+          - d84935abd3f8556dcd51d4f27e22d0a6  # WEB Tier 03
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 350 # required as this differs from the standard scoring
+            score: 350  # required as this differs from the standard scoring
       # Adjustable scoring section
       - trash_ids:
-          - 418f50b10f1907201b6cfdf881f467b7 # Anime Dual Audio
+          - 418f50b10f1907201b6cfdf881f467b7  # Anime Dual Audio
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # Adjust scoring as desired
+            score: 0  # Adjust scoring as desired
       - trash_ids:
-          - 026d5aadd1a6b4e550b134cb6c72b3ca # Uncensored
+          - 026d5aadd1a6b4e550b134cb6c72b3ca  # Uncensored
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # Adjust scoring as desired
+            score: 0  # Adjust scoring as desired
       - trash_ids:
-          - b2550eb333d27b75833e25b8c2557b38 # 10bit
+          - b2550eb333d27b75833e25b8c2557b38  # 10bit
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: 0 # Adjust scoring as desired
+            score: 0  # Adjust scoring as desired
       - trash_ids:
-          - b4a1b3d705159cdca36d71e57ca86871 # Anime Raws
+          - b4a1b3d705159cdca36d71e57ca86871  # Anime Raws
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: -10000 # Adjust scoring as desired
+            score: -10000  # Adjust scoring as desired
       - trash_ids:
-          - 9c14d194486c4014d422adc64092d794 # Dubs Only
+          - 9c14d194486c4014d422adc64092d794  # Dubs Only
         quality_profiles:
           - name: Remux-1080p - Anime
-            score: -10000 # Adjust scoring as desired
+            score: -10000  # Adjust scoring as desired

--- a/docs/recyclarr-configs/sonarr/web-1080p-v4.yml
+++ b/docs/recyclarr-configs/sonarr/web-1080p-v4.yml
@@ -1,6 +1,6 @@
 # This config file is for use with Sonarr V4 only
 sonarr:
-  sonarr: # A custom name used to identify this particular instance.
+  sonarr:  # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 

--- a/docs/recyclarr-configs/sonarr/web-2160p-v4.yml
+++ b/docs/recyclarr-configs/sonarr/web-2160p-v4.yml
@@ -1,6 +1,6 @@
 # This config file is for use with Sonarr V4 only
 sonarr:
-  sonarr: # A custom name used to identify this particular instance.
+  sonarr:  # A custom name used to identify this particular instance.
     base_url: [sonarr_url_goes_here]
     api_key: [api_key_goes_here]
 


### PR DESCRIPTION
Some default scores not set, some CFs needed moving to custom scoring section for easier identification.

# Pull request

**Purpose**
To fix and update the recyclarr anime configs for Sonarr V4 and Radarr

**Approach**
Match them to the guide, add scores where scores don't exist in the guide, move some CFs to the custom scoring sections so users know these can be manually adjusted

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
