### PR TITLE
Updated golden rule to include capital X and H

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -385,7 +385,7 @@ Add this to your `Preferred (3)` with a score of [-10000]
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?=.*(1080|720))(?=.*((x|h)[ ._-]?265|hevc)).*/i
+/^(?=.*(1080|720))(?=.*((x|h|X|H)[ ._-]?265|hevc)).*/i
 ```
 
 ??? success "example - [CLICK TO EXPAND]"


### PR DESCRIPTION
# Pull request

**Purpose**
I've noticed many show releases are listed as X265 or H265 (capital X and H).

**Approach**
I've updated the sonarr golden rule regex to include capital X or H in the filter.
E.g. simply change regex from (x|h) to (x|h|X|H).

**Open Questions and Pre-Merge TODOs**
This would probably be helpful for Radarr as well, but I don't know where and how to update it there.
