### PR TITLE
Exclude "IMAX Edition" from Special Edition CF

### DIFF
--- a/docs/json/radarr/cf/special-edition.json
+++ b/docs/json/radarr/cf/special-edition.json
@@ -1,26 +1,36 @@
 {
   "trash_id": "957d0f44b592285f26449575e8b1167e",
   "trash_score": "125",
-  "trash_regex": "https://regex101.com/r/ZUo0H1/1",
+  "trash_regex": "https://regex101.com/r/44pLFg/1",
   "name": "Special Edition",
   "includeCustomFormatWhenRenaming": false,
-  "specifications": [{
-          "name": "Special Edition",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": false,
-          "required": true,
-          "fields": {
-              "value": "(?<!^|{)\\b(extended|uncut|directors|special|unrated|uncensored|cut|version|edition)(\\b|\\d)"
-          }
-      },
-      {
-          "name": "Not Theatrical ",
-          "implementation": "ReleaseTitleSpecification",
-          "negate": true,
-          "required": true,
-          "fields": {
-              "value": "Theatrical"
-          }
+  "specifications": [
+    {
+      "name": "Special Edition",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(?<!^|{)\\b(extended|uncut|directors|special|unrated|uncensored|cut|version|edition)(\\b|\\d)"
       }
+    },
+    {
+      "name": "Not Theatrical ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "Theatrical"
+      }
+    },
+    {
+      "name": "Not IMAX Edition",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\b(IMAX[ ._-]Edition)\\b"
+      }
+    }
   ]
 }


### PR DESCRIPTION
# Pull request

**Purpose**
Special Edition matches "IMAX Edition", so adding unnecessary extra scoring to releases that already match "IMAX"

**Approach**
Add an additional negate for "IMAX Edition"

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
