### PR TITLE
fix(radarr): `Upscaled` CF not matching `Upscale`

### DIFF
--- a/docs/json/radarr/cf/upscaled.json
+++ b/docs/json/radarr/cf/upscaled.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "bfd8eb01832d646a0a89c4deb46f8564",
   "trash_score": "-10000",
-  "trash_regex": "https://regex101.com/r/HBqWdQ/1",
+  "trash_regex": "https://regex101.com/r/zOaqyg/1",
   "name": "Upscaled",
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
@@ -11,7 +11,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(Up(s(caled|UHD)|(Rez)))\\b"
+        "value": "\\b(Up(s(caled?|UHD)|(Rez)))\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
Fix the `Upscaled` CF not matching `Upscale` in the release title.
Should fix https://discord.com/channels/492590071455940612/1074721364059107388/1082678793979822190

**Approach**
Adjust the regex to match `Upscale`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
