### PR TITLE
feat(radarr): add `ONLYMOViE` to `Bad Dual Groups` CF

### DIFF
--- a/docs/json/radarr/cf/bad-dual-groups.json
+++ b/docs/json/radarr/cf/bad-dual-groups.json
@@ -104,6 +104,15 @@
       }
     },
     {
+      "name": "ONLYMOViE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(-ONLYMOViE)\\b"
+      }
+    },
+    {
       "name": "PD",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Prevent `ONLYMOViE` from being picked up, because they put french audio first.

**Approach**
Add `ONLYMOViE` to the `Bad Dual Groups` custom format.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
