### PR TITLE
Small fix for empty audio information

### DIFF
--- a/docs/json/radarr/naming/radarr-naming.json
+++ b/docs/json/radarr/naming/radarr-naming.json
@@ -6,7 +6,7 @@
       "jellyfin": "{Movie CleanTitle} ({Release Year}) [imdbid-{ImdbId}]"
   },
   "file": {
-      "default": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
+      "default": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
       "emby": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
       "jellyfin": "{Movie CleanTitle} {(Release Year)} [imdbid-{ImdbId}] - {Edition Tags }{[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}",
       "anime": "{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}]{MediaInfo AudioLanguages}[{MediaInfo VideoBitDepth}bit][{Mediainfo VideoCodec}]{-Release Group}",


### PR DESCRIPTION
This seems like it fixes an issue where AudioCodec / AudioChannels might come back empty. If this is a desired change it'd be for all the other profiles below it as well... Looking for review on this though.

Current suggestion:
```
{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}{[Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}
Foobar (1999) {imdb-tt12345678} [WEBRip-720p]][]-Group.mp4
```

My suggestion:
```
{Movie CleanTitle} {(Release Year)} {imdb-{ImdbId}} {edition-{Edition Tags}} {[Custom Formats]}{[Quality Full]}{[MediaInfo 3D]}{[MediaInfo VideoDynamicRangeType]}[{Mediainfo AudioCodec}{ Mediainfo AudioChannels}][{Mediainfo VideoCodec}]{-Release Group}
Foobar (1999) {imdb-tt12345678} [WEBRip-720p][][]-Group.mp4
```

Sadly I cannot figure out a way to NOT include the empty portions. Seems like that's up to the *arr to fix how it does string/token replacements.

# Pull request

**Purpose**
Detailed description why you created this Pull Request.

**Approach**
If this Pull Request is created to solve a issue explain how does this change address the problem?

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [ ] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
