### PR TITLE
Treat DV+HDR10 as independent expressions

### DIFF
--- a/docs/json/radarr/cf/dv-hdr10.json
+++ b/docs/json/radarr/cf/dv-hdr10.json
@@ -6,12 +6,21 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "DV HDR10",
+      "name": "DV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(DV|DoVi|Dolby[ .]?Vision)\\b"
+      }
+    },
+    {
+      "name": "HDR10",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-hlg.json
+++ b/docs/json/radarr/cf/dv-hlg.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv-sdr.json
+++ b/docs/json/radarr/cf/dv-sdr.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/dv.json
+++ b/docs/json/radarr/cf/dv.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "^\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/radarr/cf/hdr10.json
+++ b/docs/json/radarr/cf/hdr10.json
@@ -14,15 +14,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/hdr10plus-boost.json
+++ b/docs/json/radarr/cf/hdr10plus-boost.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/radarr/cf/hdr10plus.json
+++ b/docs/json/radarr/cf/hdr10plus.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/dv-hdr10.json
+++ b/docs/json/sonarr/cf/dv-hdr10.json
@@ -6,12 +6,21 @@
   "includeCustomFormatWhenRenaming": false,
   "specifications": [
     {
-      "name": "DV HDR10",
+      "name": "DV",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(DV|DoVi|Dolby[ .]?Vision)\\b"
+      }
+    },
+    {
+      "name": "HDR10",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-hlg.json
+++ b/docs/json/sonarr/cf/dv-hlg.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv-sdr.json
+++ b/docs/json/sonarr/cf/dv-sdr.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "^\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/dv.json
+++ b/docs/json/sonarr/cf/dv.json
@@ -14,12 +14,12 @@
       }
     },
     {
-      "name": "Not DV HDR10",
+      "name": "Not HDR10",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,
       "required": true,
       "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
+        "value": "\\b(HDR(10)?(?!\\+))\\b"
       }
     },
     {

--- a/docs/json/sonarr/cf/hdr10.json
+++ b/docs/json/sonarr/cf/hdr10.json
@@ -14,15 +14,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/hdr10plus-boost.json
+++ b/docs/json/sonarr/cf/hdr10plus-boost.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,

--- a/docs/json/sonarr/cf/hdr10plus.json
+++ b/docs/json/sonarr/cf/hdr10plus.json
@@ -15,15 +15,6 @@
       }
     },
     {
-      "name": "Not DV HDR10",
-      "implementation": "ReleaseTitleSpecification",
-      "negate": true,
-      "required": true,
-      "fields": {
-        "value": "^(?=.*\\b(DV|DoVi|Dolby[ .]?Vision)\\b)(?=.*\\b(HDR(10)?(?!\\+))\\b)"
-      }
-    },
-    {
       "name": "Not PQ",
       "implementation": "ReleaseTitleSpecification",
       "negate": true,


### PR DESCRIPTION
# Pull request

**Purpose**
Currently the DV+HDR10 format is treated as a unit rather than a combination of DV and HDR10.
This leads to some other formats excluding DV, then excluding DV+HDR10 (which is pointless).

**Approach**
- When positive matching, split the DV+HDR10 regex in two independent expression (both required).
- When negative matching
  - in DV formats, only look for HDR10 for exclusion
  - in non DV formats, only look for DV for exclusion

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
