### PR TITLE
Fix `PR1234`

### DIFF
--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -536,7 +536,7 @@ Add this to your `Must not contain (2)`
 Add this to your `Must not contain (2)`
 
 ```bash
-/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ])(?!DL)\b)|\b(-CAKES|-GGEZ|-GGWP|-GLHF|-GOSSIP|-NAISU|-KOGI|-PECULATE|-SLOT)).*/i
+/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ])(?!DL)\b)|\b(-CAKES|-GGEZ|-GGWP|-GLHF|-GOSSIP|-NAISU|-KOGI|-PECULATE|-SLOT).*/i
 
 ```
 

--- a/docs/json/sonarr/rp/optionals.json
+++ b/docs/json/sonarr/rp/optionals.json
@@ -16,7 +16,7 @@
   }, {
     "name": "Ignore so called scene releases",
     "trash_id": "5bc23c3a055a1a5d8bbe4fb49d80e0cb",
-    "term": "/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ])(?!DL)\\b)|\\b(-CAKES|-GGEZ|-GGWP|-GLHF|-GOSSIP|-NAISU|-KOGI|-PECULATE|-SLOT)).*/i"
+    "term": "/^(?!.*(web[ ]dl|-deflate|-inflate))(?=.*([_. ]WEB[_. ])(?!DL)\\b)|\\b(-CAKES|-GGEZ|-GGWP|-GLHF|-GOSSIP|-NAISU|-KOGI|-PECULATE|-SLOT).*/i"
   }, {
     "name": "Ignore Bad Dual Audio Groups",
     "trash_id": "538bad00ee6f8aced8e0db5218b8484c",

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,13 @@
+# 2023-03-27 19:00
+**[New]**
+- None
+
+**[Updated]**
+- None
+
+**[Fixed]**
+- [Sonarr v3] Fix copy/paste error with PR#1234 for the Optional `Scene` prevent matching on releases renamed by trackers.
+
 # 2023-03-26 11:00
 **[New]**
 - None


### PR DESCRIPTION
# 2023-03-27 19:00
**[New]**
- None

**[Updated]**
- None

**[Fixed]**
- [Sonarr v3] Fix copy/paste error with PR#1234 for the Optional `Scene` prevent matching on releases renamed by trackers.
