### PR TITLE
(update) SABnzdb Scripts compatibility update for V4.0.0 and higher.

### DIFF
--- a/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
+++ b/docs/Downloaders/SABnzbd/scripts/Clean/Clean.py
@@ -21,8 +21,12 @@ import sys
 import re
 
 try:
-    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename) = sys.argv
+    # Parse the 18 input variables for SABnzbd version >= 4.0.0
+    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename, is_proper, resolution, decade, year, month, day, job_type) = sys.argv
     downloadsize = int(downloadsize)
+except ValueError:
+    # ...or 11 variables for earlier versions
+    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename) = sys.argv
 except:
     sys.exit(1)    # exit with 1 causes SABnzbd to ignore the output of this script
 

--- a/docs/Downloaders/SABnzbd/scripts/replace_for/replace_for.py
+++ b/docs/Downloaders/SABnzbd/scripts/replace_for/replace_for.py
@@ -20,7 +20,12 @@ import os
 import os.path
 
 try:
-    (scriptname, directory, orgnzbname, jobname, reportnumber, category, group, postprocstatus, url) = sys.argv
+    try:
+    # Parse the 18 input variables for SABnzbd version >= 4.0.0
+    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename, is_proper, resolution, decade, year, month, day, job_type) = sys.argv
+except ValueError:
+    # ...or 11 variables for earlier versions
+    (scriptname, nzbname, postprocflags, category, script, prio, downloadsize, grouplist, showname, season, episodenumber, episodename) = sys.argv
 except:
     print("No commandline parameters found")
     sys.exit(1)    # exit with 1 causes SABnzbd to ignore the output of this script


### PR DESCRIPTION
# Pull request

**Purpose**
Sabnzbd Version 4.0.0 (current beta) introduced a couple of input variables, that weren't available in the versions before.
This PR fixes the two scripts in the Guide, so they are compatible with earlier and V4+ versions

**Approach**
[https://sabnzbd.org/wiki/scripts/pre-queue-scripts#toc3](https://sabnzbd.org/wiki/scripts/pre-queue-scripts#toc3)


**Requirements**
Check all boxes as they are completed

- [ ] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [ ] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
