### PR TITLE
fix(sonarr): `SHO` CF mismatching

### DIFF
--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -1,6 +1,7 @@
 {
   "trash_id": "ae58039e1319178e6be73caab5c42166",
   "trash_score": "95",
+  "trash_regex": "https://regex101.com/r/kjPPbG/1",
   "name": "SHO",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/sonarr/cf/sho.json
+++ b/docs/json/sonarr/cf/sho.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": true,
       "fields": {
-        "value": "\\b(sho|showtime)\\b"
+        "value": "\\b(sho|showtime)\\b[ ._-]web[ ._-]?(dl|rip)?\\b"
       }
     },
     {


### PR DESCRIPTION
# Pull request

**Purpose**
Fix the `SHO` CF wrongfully matching "Showtime" in the episode title.
Closes #1247 

**Approach**
Adjust the regex to account for episode titles.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
