### PR TITLE
fix(guide): unwanted CF scores

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -898,7 +898,7 @@ I also made 3 guides related to this one.
 
     This is a custom format to help Radarr recognize & ignore BR-DISK (ISO's and Blu-ray folder structure) in addition to the standard BR-DISK quality.
 
-    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-1000` or even `-10000`
+    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-10000`.
 
     !!! note
 
@@ -1024,7 +1024,7 @@ I also made 3 guides related to this one.
 ??? question "DV (WEBDL) - [CLICK TO EXPAND]"
     This is a special Custom Format that block WEBDLs **with** Dolby Vision but **without** HDR10 fallback.
 
-    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-1000` or even `-10000`
+    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-10000`.
 
     This Custom Format works together with the normal [DV](#dv) Custom Format that you can use to prefer Dolby Vision.
 
@@ -1048,7 +1048,7 @@ I also made 3 guides related to this one.
 
     This group is often banned for the low quality Blu-ray releases, but their WEB-DLs are okay.
 
-    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-1000` or even `-10000`
+    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-10000`.
 
 ??? example "JSON - [CLICK TO EXPAND]"
 

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -749,7 +749,7 @@ I also made 3 guides related to this one.
 
     This is a custom format to help Sonarr recognize & ignore BR-DISK (ISO's and Blu-ray folder structure) in addition to the standard BR-DISK quality.
 
-    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-1000` or even `-10000`
+    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-10000`.
 
     !!! note
 
@@ -942,7 +942,7 @@ I also made 3 guides related to this one.
 ??? question "DV (WEBDL) - [CLICK TO EXPAND]"
     This is a special Custom Format that block WEBDLs **with** Dolby Vision but **without** HDR10 fallback.
 
-    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-1000` or even `-10000`
+    You will need to add the following to your new Custom Format when created in your Quality Profile (`Setting` => `Profiles`) and then set the score to `-10000`.
 
     This Custom Format works together with the normal [DV](#dv) Custom Format that you can use to prefer Dolby Vision.
 

--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,18 @@
+# 2023-04-06 19:30
+**[New]**
+- None
+
+**[Updated]**
+- [Starr] Added RlsGrp `XEBEC` to CF `Web Tier 2`.
+- [Radarr] Add RlsGrp `GPTHD` to `LQ` custom format. (filenames are improperly named, hardcoded Chinese subtitles)
+
+**[Fixed]**
+- [Sonarr v4] Adjust the regex to account for episode titles. Fix the `SHO` CF wrongfully matching "Showtime" in the episode title.
+- [Guide] (Starr) Correct the scores for some `Unwanted`/`Optional` CFs in the Guides. Change the scores in the Guides from `-1000` OR `-10000` to only `-10000`.
+- [Guide] (Sonarr v4) Fixed proper description was still pointing to v3 regex.
+- [Guide] (SABnzbd) Update breakdown path image - The SABnzbd path and categories has an outdated image that have caused some conflicting.
+- [Guide] (SABnzbd) V4.0.0 (current beta) introduced a couple of input variables, that weren't available in the versions before. This PR fixes the two scripts in the Guide, so they are compatible with earlier and V4+ versions.
+
 # 2023-03-27 19:00
 **[New]**
 - None


### PR DESCRIPTION
# Pull request

**Purpose**
Correct the scores for some `Unwanted`/`Optional` CFs in the Guides.
Fixes #1252 

**Approach**
Change the scores in the Guides from `-1000` OR `-10000` to only `-10000`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
