### PR TITLE
Updated recyclarr configs

### DIFF
--- a/docs/recyclarr-configs/radarr/anime-radarr.yml
+++ b/docs/recyclarr-configs/radarr/anime-radarr.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: movie
 
+    quality_profiles:
+      - name: Remux-1080p - Anime
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -34,7 +38,6 @@ radarr:
           - 60f6d50cbd3cfc3e9a8c00e3a30c3114  # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
-            reset_unmatched_scores: true
       # Custom Scoring
       # Anime CF/Scoring
       - trash_ids:

--- a/docs/recyclarr-configs/radarr/hd-bluray-web.yml
+++ b/docs/recyclarr-configs/radarr/hd-bluray-web.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: movie
 
+    quality_profiles:
+      - name: HD Bluray + WEB
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -38,7 +42,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: HD Bluray + WEB
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services

--- a/docs/recyclarr-configs/radarr/remux-web-1080p.yml
+++ b/docs/recyclarr-configs/radarr/remux-web-1080p.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: movie
 
+    quality_profiles:
+      - name: Remux + WEB 1080p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -53,7 +57,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux + WEB 1080p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services

--- a/docs/recyclarr-configs/radarr/remux-web-2160p.yml
+++ b/docs/recyclarr-configs/radarr/remux-web-2160p.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: movie
 
+    quality_profiles:
+      - name: Remux + WEB 2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -68,7 +72,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux + WEB 2160p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services

--- a/docs/recyclarr-configs/radarr/sqp/sqp-1.yml
+++ b/docs/recyclarr-configs/radarr/sqp/sqp-1.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: sqp-streaming
 
+    quality_profiles:
+      - name: Bluray|WEB-1080p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -51,7 +55,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Bluray|WEB-1080p
-            reset_unmatched_scores: true
       # Custom Scoring
       # HQ Release Groups - Optional - Uncomment the next section (10 lines) to enable other Bluray Encodes (less or not streaming optimized)
       # - trash_ids:

--- a/docs/recyclarr-configs/radarr/sqp/sqp-2.yml
+++ b/docs/recyclarr-configs/radarr/sqp/sqp-2.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: sqp-uhd
 
+    quality_profiles:
+      - name: Remux|Bluray|IMAX-E|2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -83,7 +87,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux|Bluray|IMAX-E|2160p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Resolution

--- a/docs/recyclarr-configs/radarr/sqp/sqp-3.yml
+++ b/docs/recyclarr-configs/radarr/sqp/sqp-3.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: sqp-uhd
 
+    quality_profiles:
+      - name: Remux|IMAX-E|2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -80,7 +84,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Remux|IMAX-E|2160p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Resolution

--- a/docs/recyclarr-configs/radarr/sqp/sqp-4.yml
+++ b/docs/recyclarr-configs/radarr/sqp/sqp-4.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: sqp-uhd
 
+    quality_profiles:
+      - name: WEBDL|IMAX-E|2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -79,7 +83,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: WEBDL|IMAX-E|2160p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Resolution

--- a/docs/recyclarr-configs/radarr/sqp/sqp-5.yml
+++ b/docs/recyclarr-configs/radarr/sqp/sqp-5.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: sqp-uhd
 
+    quality_profiles:
+      - name: Bluray|IMAX-E|2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -82,7 +86,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: Bluray|IMAX-E|2160p
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Resolution

--- a/docs/recyclarr-configs/radarr/uhd-bluray-web.yml
+++ b/docs/recyclarr-configs/radarr/uhd-bluray-web.yml
@@ -6,6 +6,10 @@ radarr:
     quality_definition:
       type: movie
 
+    quality_profiles:
+      - name: UHD Bluray + WEB
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -69,7 +73,6 @@ radarr:
           - 2a6039655313bf5dab1e43523b62c374  # MA
         quality_profiles:
           - name: UHD Bluray + WEB
-            reset_unmatched_scores: true
       # Custom Scoring
       - trash_ids:
           # Streaming Services

--- a/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
+++ b/docs/recyclarr-configs/sonarr/anime-sonarr-v4.yml
@@ -7,6 +7,10 @@ sonarr:
     quality_definition:
       type: anime
 
+    quality_profiles:
+      - name: Remux-1080p - Anime
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -40,7 +44,6 @@ sonarr:
           - 44a8ee6403071dd7b8a3a8dd3fe8cb20  # VRV
         quality_profiles:
           - name: Remux-1080p - Anime
-            reset_unmatched_scores: true
       # Custom scoring
       - trash_ids:
           # Anime Streaming Services

--- a/docs/recyclarr-configs/sonarr/web-1080p-v4.yml
+++ b/docs/recyclarr-configs/sonarr/web-1080p-v4.yml
@@ -7,6 +7,10 @@ sonarr:
     quality_definition:
       type: series
 
+    quality_profiles:
+      - name: WEB-1080p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -44,4 +48,3 @@ sonarr:
           - d0c516558625b04b363fa6c5c2c7cfd4  # WEB Scene
         quality_profiles:
           - name: WEB-1080p
-            reset_unmatched_scores: true

--- a/docs/recyclarr-configs/sonarr/web-2160p-v4.yml
+++ b/docs/recyclarr-configs/sonarr/web-2160p-v4.yml
@@ -7,6 +7,10 @@ sonarr:
     quality_definition:
       type: series
 
+    quality_profiles:
+      - name: WEB-2160p
+        reset_unmatched_scores: true
+
     custom_formats:
       # Scores from TRaSH json
       - trash_ids:
@@ -59,4 +63,3 @@ sonarr:
           - d0c516558625b04b363fa6c5c2c7cfd4  # WEB Scene
         quality_profiles:
           - name: WEB-2160p
-            reset_unmatched_scores: true


### PR DESCRIPTION
Updated recyclarr configs to support new YML configuration requirements for `reset_unmatched_scores`.

# Pull request

**Purpose**
YML configuration for `reset_unmatched_scores` is changing in recyclarr v5, and is also supported in the newly released v4.4.0.

**Approach**
Relocate `reset_unmatched_scores` configuration item.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
