### PR TITLE
feat(sonarr): add HiQVE to LQ

### DIFF
--- a/docs/json/sonarr/cf/lq.json
+++ b/docs/json/sonarr/cf/lq.json
@@ -50,6 +50,15 @@
       }
     },
     {
+      "name": "HiQVE",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HiQVE)$"
+      }
+    },
+    {
       "name": "JFF",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Prevent `HiQVE` releases from getting grabbed, because the do x265 encodes with their tag hardcoded in the top right.
Closes #1279 

**Approach**
Add `HiQVE` to the `LQ` CF.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
