### PR TITLE
Update 10bit.json for sonarr to support hyphens

### DIFF
--- a/docs/json/sonarr/cf/10bit.json
+++ b/docs/json/sonarr/cf/10bit.json
@@ -9,7 +9,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "10\\.?bit"
+        "value": "10[.-]?bit"
       }
     },
     {


### PR DESCRIPTION
In addition to `10bit` and `10.bit`, some releases I've seen on animebytes have the substring `10-bit`. This change supports that.

Example: https://regex101.com/r/6FX1ts/1

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
