### PR TITLE
Update Android-SHIELD-Android-TV.xml

### DIFF
--- a/docs/Plex/profiles/Android-SHIELD/Android-SHIELD-Android-TV.xml
+++ b/docs/Plex/profiles/Android-SHIELD/Android-SHIELD-Android-TV.xml
@@ -9,7 +9,7 @@
     <PhotoProfile container="jpeg" />
   </TranscodeTargets>
   <DirectPlayProfiles>
-    <VideoProfile container="mkv" codec="vp9,hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="eac3,ac3,aac,mp3,mp2,pcm,flac,alac,truehd,dca" subtitleFormat="srt,ass,smi,ssa,subrip,pgs"/>
+    <VideoProfile container="mkv" codec="vp9,hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="eac3,ac3,aac,mp3,mp2,pcm,flac,alac,truehd,dca" subtitleCodec="srt,ass,smi,ssa,subrip,pgs"/>
     <VideoProfile container="mp4" codec="hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="eac3,ac3,aac,mp3,mp2,pcm,flac,alac,truehd,dca" subtitleCodec="srt,ass,smi,ssa,subrip,pgs"/>
     <VideoProfile container="asf" codec="wmv3,wmv3,vc1" audioCodec="wmav2,wmav2,wmapro,wmavoice,pcm" subtitleCodec="srt,ass,smi,ssa,subrip,pgs"/>
     <VideoProfile container="avi" codec="h264,msmpeg4v3,mpeg4,mjpeg" audioCodec="mp3,ac3,eac3,dca,pcm" subtitleCodec="srt,ass,smi,ssa,subrip,pgs"/>


### PR DESCRIPTION
# Pull request

**Purpose**
Shouldn't SubtitleFormat be SubtitleCodec?

**Approach**
Everywhere I see working profiles on the Plex forum everyone uses only SubtitleCodec, never SubtitleFormat

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [X] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
