### PR TITLE
Update Chromecast.xml

### DIFF
--- a/docs/Plex/profiles/Chromecast/Chromecast.xml
+++ b/docs/Plex/profiles/Chromecast/Chromecast.xml
@@ -9,7 +9,7 @@
   </TranscodeTargets>
   <DirectPlayProfiles>
     <VideoProfile container="mp4" codec="Hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="aac,mp3,mp2"/>
-    <VideoProfile container="mkv" codec="vp9,Hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="aac,mp3,mp2,pcm,flac,alac" subtitleFormat="srt,ass"/>
+    <VideoProfile container="mkv" codec="vp9,Hevc,h265,mpeg1video,mpeg2video,h264,mpeg4" audioCodec="aac,mp3,mp2,pcm,flac,alac" subtitleCodec="srt,ass"/>
     <VideoProfile protocol="hls" container="mpegts" codec="h264" audioCodec="aac" />
     <MusicProfile container="mp3" codec="mp2,mp3"/>
     <MusicProfile container="mp4" codec="aac"/>


### PR DESCRIPTION
# Pull request

**Purpose**
Shouldn't SubtiteFormat be SubtitleCodec?

**Approach**
Everywhere I see working profiles on the Plex forum everyone uses only SubtitleCodec, never SubtitleFormat.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [X] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [X] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [X] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
