### PR TITLE
Sonarr v4 Special CF BR-DISK for BTN

### DIFF
--- a/docs/json/sonarr/cf/br-disk-btn.json
+++ b/docs/json/sonarr/cf/br-disk-btn.json
@@ -1,0 +1,18 @@
+{
+  "trash_id": "6f808933a71bd9666531610cb8c059cc",
+  "trash_score": "-10000",
+  "name": "BR-DISK (BTN)",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "BR-DISK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "^(?!.*\\b((?<!HD[._ -]|HD)DVD|BDRip|MKV|XviD|WMV|d3g|BDREMUX|REMUX|^(?=.*1080p)(?=.*HEVC)|[x][-_. ]?26[45]|German.*DL|((?<=\\d{4}).*German.*(DL)?)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2)\\b))\\b)(((?=.*\\b(Blu[-_. ]?ray|BD|HD[-_. ]?DVD)\\b)(?=.*\\b(AVC|HEVC|VC[-_. ]?1|MVC|MPEG[-_. ]?2|BDMV|ISO|H[ ._-]?26[45])\\b))|^((?=.*\\b(^((?=.*\\b((.*_)?COMPLETE.*|Dis[ck])\\b)(?=.*(Blu[-_. ]?ray|HD[-_. ]?DVD)))|3D[-_. ]?BD|BR[-_. ]?DISK|Full[-_. ]?Blu[-_. ]?ray|^((?=.*((BD|UHD)[-_. ]?(25|50|66|100|ISO)))))))).*"
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
- NEW: CF `BR-DISK (BTN)`, being that BTN renames their BR-DISK wrong (and why rename in the first place ? ex AVC to H.264), they aren't detected as BR-DISK for this I edited the normal CF `BR-DISK` so it will be recognized, but this could also result in a few false positive. that's why it won't be added to the original `BR-DISK`. it's best to just use both.

