### PR TITLE
fix(radarr): VS false positives

### DIFF
--- a/docs/json/radarr/cf/vinegar-syndrome.json
+++ b/docs/json/radarr/cf/vinegar-syndrome.json
@@ -19,7 +19,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(V-?S)\\b"
+        "value": "\\b(V-S)\\b"
       }
     }
   ]


### PR DESCRIPTION
# Pull request

**Purpose**
Fix false positive matches on `vs` in movie titles for the `Vinegar Syndrome` CF.
Fixes #1314 

**Approach**
Make `-` non-optional.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
