### PR TITLE
feat(starr): add Max CF

### DIFF
--- a/docs/Radarr/Radarr-collection-of-custom-formats.md
+++ b/docs/Radarr/Radarr-collection-of-custom-formats.md
@@ -54,12 +54,13 @@ I also made 3 guides related to this one.
 | [4K Remaster](#4k-remaster)                   | [3D](#3d)             | [Remux Tier 03](#remux-tier-03)           | [Disney+](#dsnp)       |
 | [Special Edition](#special-edition)           | [x265 (HD)](#x265-hd) | [UHD Bluray Tier 01](#uhd-bluray-tier-01) | [HBO](#hbo)            |
 | [Criterion Collection](#criterion-collection) | [Upscaled](#upscaled) | [UHD Bluray Tier 02](#uhd-bluray-tier-02) | [HBO Max](#hmax)       |
-| [Masters of Cinema](#masters-of-cinema)       |                       | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [Hulu](#hulu)          |
-| [Vinegar Syndrome](#vinegar-syndrome)         |                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [Netflix](#nf)         |
-| [Theatrical Cut](#theatrical-cut)             |                       | [HD Bluray Tier 02](#hd-bluray-tier-02)   | [Peacock TV](#pcok)    |
-| [IMAX](#imax)                                 |                       | [WEB Tier 01](#web-tier-01)               | [Paramount+](#pmtp)    |
-| [IMAX Enhanced](#imax-enhanced)               |                       | [WEB Tier 02](#web-tier-02)               | [Movies Anywhere](#ma) |
-| [Open Matte](#open-matte)                     |                       | [WEB Tier 03](#web-tier-03)               | [Pathe Thuis](#pathe)  |
+| [Masters of Cinema](#masters-of-cinema)       |                       | [UHD Bluray Tier 03](#uhd-bluray-tier-03) | [Max](#max)            |
+| [Vinegar Syndrome](#vinegar-syndrome)         |                       | [HD Bluray Tier 01](#hd-bluray-tier-01)   | [Hulu](#hulu)          |
+| [Theatrical Cut](#theatrical-cut)             |                       | [HD Bluray Tier 02](#hd-bluray-tier-02)   | [Netflix](#nf)         |
+| [IMAX](#imax)                                 |                       | [WEB Tier 01](#web-tier-01)               | [Peacock TV](#pcok)    |
+| [IMAX Enhanced](#imax-enhanced)               |                       | [WEB Tier 02](#web-tier-02)               | [Paramount+](#pmtp)    |
+| [Open Matte](#open-matte)                     |                       | [WEB Tier 03](#web-tier-03)               | [Movies Anywhere](#ma) |
+|                                               |                       |                                           | [Pathe Thuis](#pathe)  |
 |                                               |                       |                                           | [Bravia Core](#bcore)  |
 |                                               |                       |                                           | [Stan](#stan)          |
 
@@ -1680,6 +1681,24 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/radarr/cf/hmax.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### Max
+
+<sub>Max</sub>
+
+??? question "Max - [CLICK TO EXPAND]"
+
+    [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Max_(streaming_service)){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/radarr/cf/max.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
+++ b/docs/Sonarr/Sonarr-Release-Profile-RegEx.md
@@ -165,6 +165,10 @@ Add this to your `Preferred (3)` with a score of [90]
 /\b(hmax|hbom|hbo[ ._-]max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
 ```
 
+```bash
+/\b((?<!hbo[ ._-])max)\b(?=[ ._-]web[ ._-]?(dl|rip)\b)/i
+```
+
 Add this to your `Preferred (3)` with a score of [85]
 
 ```bash

--- a/docs/Sonarr/sonarr-collection-of-custom-formats.md
+++ b/docs/Sonarr/sonarr-collection-of-custom-formats.md
@@ -53,8 +53,9 @@ I also made 3 guides related to this one.
 |                       |                       | [HD Bluray Tier 02](#hd-bluray-tier-02) | [Disney+](#dsnp)      |
 |                       |                       | [WEB Tier 01](#web-tier-01)             | [HBO Max](#hmax)      |
 |                       |                       | [WEB Tier 02](#web-tier-02)             | [HBO](#hbo)           |
-|                       |                       | [WEB Tier 03](#web-tier-03)             | [Hulu](#hulu)         |
-|                       |                       | [WEB Scene](#web-scene)                 | [NLZiet](#nlz)        |
+|                       |                       | [WEB Tier 03](#web-tier-03)             | [Max](#max)           |
+|                       |                       | [WEB Scene](#web-scene)                 | [Hulu](#hulu)         |
+|                       |                       |                                         | [NLZiet](#nlz)        |
 |                       |                       |                                         | [Netflix](#nf)        |
 |                       |                       |                                         | [Paramount+](#pmtp)   |
 |                       |                       |                                         | [Peacock TV](#pcok)   |
@@ -1426,6 +1427,24 @@ I also made 3 guides related to this one.
 
     ```json
     [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/hbo.json' %]][[% endfilter %]]
+    ```
+
+<sub><sup>[TOP](#index)</sup>
+
+------
+
+### Max
+
+<sub>Max</sub>
+
+??? question "Max - [CLICK TO EXPAND]"
+
+    [From Wikipedia, the free encyclopedia](https://en.wikipedia.org/wiki/Max_(streaming_service)){:target="_blank" rel="noopener noreferrer"}
+
+??? example "JSON - [CLICK TO EXPAND]"
+
+    ```json
+    [[% filter indent(width=4) %]][[% include 'json/sonarr/cf/max.json' %]][[% endfilter %]]
     ```
 
 <sub><sup>[TOP](#index)</sup>

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -1,10 +1,10 @@
 {
   "trash_id": "26a4b44a837bf97b972628509912b4a5",
-  "name": "MAX",
+  "name": "Max",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "MAX",
+      "name": "Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -1,5 +1,5 @@
 {
-  "trash_id": "26a4b44a837bf97b972628509912b4a5",
+  "trash_id": "6a061313d22e51e0f25b7cd4dc065233",
   "name": "Max",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [

--- a/docs/json/radarr/cf/max.json
+++ b/docs/json/radarr/cf/max.json
@@ -1,0 +1,34 @@
+{
+  "trash_id": "26a4b44a837bf97b972628509912b4a5",
+  "name": "MAX",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "MAX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -1,11 +1,11 @@
 {
-  "trash_id": "91dd233816c14c507782b87b86a3a2cf",
+  "trash_id": "81d1fbf600e2540cee87f3a23f9d3c1c",
   "trash_score": "90",
   "name": "Max",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {
-      "name": "MAX",
+      "name": "Max",
       "implementation": "ReleaseTitleSpecification",
       "negate": false,
       "required": true,

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -1,7 +1,7 @@
 {
   "trash_id": "91dd233816c14c507782b87b86a3a2cf",
   "trash_score": "90",
-  "name": "MAX",
+  "name": "Max",
   "includeCustomFormatWhenRenaming": true,
   "specifications": [
     {

--- a/docs/json/sonarr/cf/max.json
+++ b/docs/json/sonarr/cf/max.json
@@ -1,0 +1,35 @@
+{
+  "trash_id": "91dd233816c14c507782b87b86a3a2cf",
+  "trash_score": "90",
+  "name": "MAX",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "MAX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)"
+      }
+    },
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    }
+  ]
+}

--- a/docs/json/sonarr/rp/streaming.json
+++ b/docs/json/sonarr/rp/streaming.json
@@ -22,7 +22,8 @@
         "/\\b(dsnp|dsny|disney|Disney\\+)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(nf|netflix)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
         "/\\b(qibi|quibi)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
-        "/\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
+        "/\\b(hmax|hbom|hbo[ ._-]max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i",
+        "/\\b((?<!hbo[ ._-])max)\\b(?=[ ._-]web[ ._-]?(dl|rip)\\b)/i"
       ]
     },
     {

--- a/includes/cf/radarr-streaming-services.md
+++ b/includes/cf/radarr-streaming-services.md
@@ -7,6 +7,7 @@
     | [{{ radarr['cf']['dsnp']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#dsnp)   | 0                                          | {{ radarr['cf']['dsnp']['trash_id'] }}  |
     | [{{ radarr['cf']['hbo']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hbo)     | 0                                          | {{ radarr['cf']['hbo']['trash_id'] }}   |
     | [{{ radarr['cf']['hmax']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hmax)   | 0                                          | {{ radarr['cf']['hmax']['trash_id'] }}  |
+    | [{{ radarr['cf']['max']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#max)     | 0                                          | {{ radarr['cf']['max']['trash_id'] }}  |
     | [{{ radarr['cf']['hulu']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#hulu)   | 0                                          | {{ radarr['cf']['hulu']['trash_id'] }}  |
     | [{{ radarr['cf']['ma']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#ma)       | {{ radarr['cf']['ma']['trash_score'] }}    | {{ radarr['cf']['ma']['trash_id'] }}    |
     | [{{ radarr['cf']['nf']['name'] }}](/Radarr/Radarr-collection-of-custom-formats/#nf)       | 0                                          | {{ radarr['cf']['nf']['trash_id'] }}    |

--- a/includes/cf/sonarr-streaming-services.md
+++ b/includes/cf/sonarr-streaming-services.md
@@ -7,6 +7,7 @@
     | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp) | {{ sonarr['cf']['dsnp']['trash_score'] }} | {{ sonarr['cf']['dsnp']['trash_id'] }} |
     | [{{ sonarr['cf']['hbo']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hbo)   | {{ sonarr['cf']['hbo']['trash_score'] }}  | {{ sonarr['cf']['hbo']['trash_id'] }}  |
     | [{{ sonarr['cf']['hmax']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hmax) | {{ sonarr['cf']['hmax']['trash_score'] }} | {{ sonarr['cf']['hmax']['trash_id'] }} |
+    | [{{ sonarr['cf']['max']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#max)   | {{ sonarr['cf']['max']['trash_score'] }}  | {{ sonarr['cf']['max']['trash_id'] }} |
     | [{{ sonarr['cf']['hulu']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hulu) | {{ sonarr['cf']['hulu']['trash_score'] }} | {{ sonarr['cf']['hulu']['trash_id'] }} |
     | [{{ sonarr['cf']['it']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#it)     | {{ sonarr['cf']['it']['trash_score'] }}   | {{ sonarr['cf']['it']['trash_id'] }}   |
     | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)     | {{ sonarr['cf']['nf']['trash_score'] }}   | {{ sonarr['cf']['nf']['trash_id'] }}   |


### PR DESCRIPTION
# Pull request

**Purpose**
Add `Max` CF to match the renamed `HBO Max` streaming service.

**Approach**
Add the `Max` CF to all the jsons and guides.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
