### PR TITLE
Maintance Release 20230524

### DIFF
--- a/docs/updates.txt
+++ b/docs/updates.txt
@@ -1,3 +1,14 @@
+# 2023-05-24 19:30
+**[New]**
+- [Starr] Add `Max` CF to match the renamed `HBO Max` streaming service.
+- [Starr] Add RlsGrp `Kitsune` to `WEB Tier 02`.
+
+**[Updated]**
+- [Starr] Add the `Max` CF to all the jsons and guides.
+
+**[Fixed]**
+- [Radarr] Fix false positive matches on vs in movie titles for the `Vinegar Syndrome` CF.
+
 # 2023-05-18 12:00
 **[New]**
 - [Radarr] Added CF `Remux Tier 03`, This way we can fine tune the RlsGrps even more. please update your automation sync tools to accept the new CF.


### PR DESCRIPTION
# 2023-05-24 19:30
**[New]**
- [Starr] Add `Max` CF to match the renamed `HBO Max` streaming service.
- [Starr] Add RlsGrp `Kitsune` to `WEB Tier 02`.

**[Updated]**
- [Starr] Add the `Max` CF to all the jsons and guides.

**[Fixed]**
- [Radarr] Fix false positive matches on vs in movie titles for the `Vinegar Syndrome` CF.

