### PR TITLE
feat(radarr): add OFT to LQ

### DIFF
--- a/docs/json/radarr/cf/lq.json
+++ b/docs/json/radarr/cf/lq.json
@@ -446,6 +446,15 @@
       }
     },
     {
+      "name": "OFT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(OFT)$"
+      }
+    },
+    {
       "name": "Pahe",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Add `OFT` to the `LQ` CF, because they are a continuation group of nikt0.
Fixes #1341 

**Approach**
Add `OFT` to the `LQ` CF.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
