### PR TITLE
feat(radarr): add HiDt to HD Bluray Tier 02

### DIFF
--- a/docs/json/radarr/cf/hd-bluray-tier-02.json
+++ b/docs/json/radarr/cf/hd-bluray-tier-02.json
@@ -41,6 +41,15 @@
       }
     },
     {
+      "name": "HiDt",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(HiDt)$"
+      }
+    },
+    {
       "name": "HiSD",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Put `HiDt` into the HD Bluray Tiers because they got a number of GP releases on PTP and recently started to release again after a longer downtime.

**Approach**
Add `HiDt` to the `HD Bluray Tier 02` CF.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
