### PR TITLE
Update SQP1 / SQP1 2160p Minimum Score Guidance

### DIFF
--- a/includes/sqp/1-4k-qp-settings-sqp1.md
+++ b/includes/sqp/1-4k-qp-settings-sqp1.md
@@ -5,7 +5,7 @@
 - **Minimum Custom Format Score:** `1000` <sup>(*1*)</sup>
 - **Upgrade Until Custom Format Score:** `10000`
 
-!!! info "<sup>(*1*)</sup> If you're limited to public indexers or, not have access to the top tier indexers you might want to lower the `Minimum Custom Format Score` to 10."
+!!! info "<sup>(*1*)</sup> If you're limited to public indexers, don't have access to top-tier indexers, or are searching for content that is more rare, you might want to lower the `Minimum Custom Format Score` to 10."
 
 ??? success "example - [CLICK TO EXPAND]"
     ![!Quality Profile Settings](/SQP/images/1-4k-qp-settings-sqp1.png)

--- a/includes/sqp/1-4k-qp-settings.md
+++ b/includes/sqp/1-4k-qp-settings.md
@@ -5,7 +5,7 @@
 - **Minimum Custom Format Score:** `1000` <sup>(*1*)</sup>
 - **Upgrade Until Custom Format Score:** `10000`
 
-!!! info "<sup>(*1*)</sup> If you're limited to public indexers or, not have access to the top tier indexers you might want to lower the `Minimum Custom Format Score` to 10."
+!!! info "<sup>(*1*)</sup> If you're limited to public indexers, don't have access to top-tier indexers, or are searching for content that is more rare, you might want to lower the `Minimum Custom Format Score` to 10."
 
 ??? success "example - [CLICK TO EXPAND]"
     ![!Quality Profile Settings](/SQP/images/1-4k-qp-settings.png)

--- a/includes/sqp/1-qp-settings.md
+++ b/includes/sqp/1-qp-settings.md
@@ -5,7 +5,7 @@
 - **Minimum Custom Format Score:** `1000` <sup>(*1*)</sup>
 - **Upgrade Until Custom Format Score:** `10000`
 
-!!! info "<sup>(*1*)</sup> If you're limited to public indexers or, not have access to the top tier indexers you might want to lower the `Minimum Custom Format Score` to 10."
+!!! info "<sup>(*1*)</sup> If you're limited to public indexers, don't have access to top-tier indexers, or are searching for content that is more rare, you might want to lower the `Minimum Custom Format Score` to 10."
 
 ??? success "example - [CLICK TO EXPAND]"
     ![!Quality Profile Settings](/SQP/images/1-qp-settings.png)


### PR DESCRIPTION
Update the information as to why a user may want to lower the minimum quality profile score from 1000 to 10

# Pull request

**Purpose**
To amend the reasoning behind why a user may want to lower the SQP-1/SQP-1 (2160p) minimum QP score

**Approach**
Amend the text to include 'searching for content that is more rare' as a valid reason to lower the score.

**Open Questions and Pre-Merge TODOs**
Check all boxes as they are completed

- [x] Use github checklists. When solved, check the box and explain the answer.

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
