### PR TITLE
feat(radarr): add CiNEPHiLES to Remux Tier 02

### DIFF
--- a/docs/json/radarr/cf/remux-tier-02.json
+++ b/docs/json/radarr/cf/remux-tier-02.json
@@ -14,6 +14,15 @@
       }
     },
     {
+      "name": "CiNEPHiLES",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(CiNEPHiLES)$"
+      }
+    },
+    {
       "name": "Flights",
       "implementation": "ReleaseGroupSpecification",
       "negate": false,


### PR DESCRIPTION
# Pull request

**Purpose**
Fix #1374

**Approach**
Add `CiNEPHiLES` to `Remux Tier 02`.

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
