### PR TITLE
fix(anime): updated dubs only for sonarr and updated anime streaming services

### DIFF
--- a/docs/json/sonarr/cf/dubs-only.json
+++ b/docs/json/sonarr/cf/dubs-only.json
@@ -10,7 +10,7 @@
       "negate": false,
       "required": false,
       "fields": {
-        "value": "\\b(dub(bed)?)\\b|(funi|eng(lish)?)_?dub"
+        "value": "(?<!multi-)\\b(dub(bed)?)\\b|(funi|eng(lish)?)_?dub"
       }
     },
     {

--- a/includes/cf/sonarr-streaming-services-anime.md
+++ b/includes/cf/sonarr-streaming-services-anime.md
@@ -1,12 +1,13 @@
 ??? abstract "Anime Streaming Services - [CLICK TO EXPAND]"
     | Custom Format                                                                                   | Score                                     | Trash ID                                   |
     | ----------------------------------------------------------------------------------------------- | ----------------------------------------- | ------------------------------------------ |
+    | [{{ sonarr['cf']['cr']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cr)             | {{ sonarr['cf']['cr']['trash_score'] }}   | {{ sonarr['cf']['cr']['trash_id'] }}       |
+    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp)         | 5                                         | {{ sonarr['cf']['dsnp']['trash_id'] }}     |
+    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)             | 4                                         | {{ sonarr['cf']['nf']['trash_id'] }}       |
     | [{{ sonarr['cf']['amzn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#amzn)         | 3                                         | {{ sonarr['cf']['amzn']['trash_id'] }}     |
+    | [{{ sonarr['cf']['vrv']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vrv)           | {{ sonarr['cf']['vrv']['trash_score'] }}  | {{ sonarr['cf']['vrv']['trash_id'] }}      |
+    | [{{ sonarr['cf']['funi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#funi)         | {{ sonarr['cf']['funi']['trash_score'] }} | {{ sonarr['cf']['funi']['trash_id'] }}     |
+    | [{{ sonarr['cf']['french-adn']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#adn)    | 1                                         | {{ sonarr['cf']['french-adn']['trash_id'] }} |
     | [{{ sonarr['cf']['bglobal']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#b-global)  | 0                                         | {{ sonarr['cf']['bglobal']['trash_id'] }}  |
     | [{{ sonarr['cf']['bilibili']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#bilibili) | 0                                         | {{ sonarr['cf']['bilibili']['trash_id'] }} |
-    | [{{ sonarr['cf']['cr']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#cr)    | {{ sonarr['cf']['cr']['trash_score'] }}   | {{ sonarr['cf']['cr']['trash_id'] }}       |
-    | [{{ sonarr['cf']['dsnp']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#dsnp)         | 5                                         | {{ sonarr['cf']['dsnp']['trash_id'] }}     |
-    | [{{ sonarr['cf']['funi']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#funi)   | {{ sonarr['cf']['funi']['trash_score'] }} | {{ sonarr['cf']['funi']['trash_id'] }}     |
     | [{{ sonarr['cf']['hidive']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#hidive)     | 0                                         | {{ sonarr['cf']['hidive']['trash_id'] }}   |
-    | [{{ sonarr['cf']['nf']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#nf)             | 4                                         | {{ sonarr['cf']['nf']['trash_id'] }}       |
-    | [{{ sonarr['cf']['vrv']['name'] }}](/Sonarr/sonarr-collection-of-custom-formats/#vrv)           | {{ sonarr['cf']['vrv']['trash_score'] }}  | {{ sonarr['cf']['vrv']['trash_id'] }}      |


### PR DESCRIPTION
**Purpose**
Updated dubs only CF for Sonarr and streaming services Anime guide
Changelog update not needed as these were part of the previous update that were missed

**Learning**
If you're adding a new Custom Format make sure you follow the [Radarr/Sonarr Custom Format (JSON) Guidelines](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).

**Requirements**
Check all boxes as they are completed

- [x] These changes meet the standards for [contributing](https://github.com/TRaSH-/Guides/blob/master/.github/CONTRIBUTING.md).
- [x] I have read the [code of conduct](https://github.com/TRaSH-/Guides/blob/master/.github/CODE_OF_CONDUCT.md).
